### PR TITLE
Fix for settings not saving under mono 6.12

### DIFF
--- a/UI/Forms/BaseConfigForm.cs
+++ b/UI/Forms/BaseConfigForm.cs
@@ -140,11 +140,13 @@ namespace Mesen.GUI.Forms
 
 		private void btnOK_Click(object sender, EventArgs e)
 		{
+			this.DialogResult = ((Button)sender).DialogResult;
 			this.Close();
 		}
 
 		private void btnCancel_Click(object sender, EventArgs e)
 		{
+			this.DialogResult = ((Button)sender).DialogResult;
 			this.Close();
 		}
 	}


### PR DESCRIPTION
This fix addresses issues #40 and #16.