### PR TITLE
Enable disabling invalid (L+R) inputs

### DIFF
--- a/Core/SettingTypes.h
+++ b/Core/SettingTypes.h
@@ -306,6 +306,8 @@ struct EmulationConfig
 	RamState RamPowerOnState = RamState::Random;
 
 	int64_t BsxCustomDate = -1;
+
+	bool AllowInvalidInput = false;
 };
 
 struct GameboyConfig

--- a/Core/SnesController.cpp
+++ b/Core/SnesController.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "EmuSettings.h"
 #include "SnesController.h"
 #include "Console.h"
 
@@ -14,6 +15,9 @@ string SnesController::GetKeyNames()
 
 void SnesController::InternalSetStateFromInput()
 {
+	shared_ptr<EmuSettings> settings = _console->GetSettings();
+	bool allowInvalidInput = settings->GetEmulationConfig().AllowInvalidInput;
+
 	for(KeyMapping keyMapping : _keyMappings) {
 		SetPressedState(Buttons::A, keyMapping.A);
 		SetPressedState(Buttons::B, keyMapping.B);
@@ -37,6 +41,18 @@ void SnesController::InternalSetStateFromInput()
 			SetPressedState(Buttons::Y, keyMapping.TurboY);
 			SetPressedState(Buttons::L, keyMapping.TurboL);
 			SetPressedState(Buttons::R, keyMapping.TurboR);
+		}
+
+		if (!allowInvalidInput) {
+			//If both U+D or L+R are pressed at the same time, act as if neither is pressed
+			if (IsPressed(Buttons::Up) && IsPressed(Buttons::Down)) {
+				ClearBit(Buttons::Down);
+				ClearBit(Buttons::Up);
+			}
+			if (IsPressed(Buttons::Left) && IsPressed(Buttons::Right)) {
+				ClearBit(Buttons::Left);
+				ClearBit(Buttons::Right);
+			}
 		}
 	}
 }

--- a/UI/Config/EmulationConfig.cs
+++ b/UI/Config/EmulationConfig.cs
@@ -29,6 +29,8 @@ namespace Mesen.GUI.Config
 
 		public long BsxCustomDate = -1;
 
+		[MarshalAs(UnmanagedType.I1)] public bool AllowInvalidInput = false;
+
 		public void ApplyConfig()
 		{
 			ConfigApi.SetEmulationConfig(this);

--- a/UI/Forms/Config/frmEmulationConfig.Designer.cs
+++ b/UI/Forms/Config/frmEmulationConfig.Designer.cs
@@ -58,6 +58,7 @@
 			this.dtpBsxCustomTime = new System.Windows.Forms.DateTimePicker();
 			this.tpgAdvanced = new System.Windows.Forms.TabPage();
 			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+			this.chkAllowInvalidInput = new Mesen.GUI.Controls.ctrlRiskyOption();
 			this.chkEnableRandomPowerOnState = new Mesen.GUI.Controls.ctrlRiskyOption();
 			this.cboRamPowerOnState = new System.Windows.Forms.ComboBox();
 			this.lblRamPowerOnState = new System.Windows.Forms.Label();
@@ -98,7 +99,7 @@
 			// baseConfigPanel
 			// 
 			this.baseConfigPanel.Location = new System.Drawing.Point(0, 290);
-			this.baseConfigPanel.Size = new System.Drawing.Size(445, 29);
+			this.baseConfigPanel.Size = new System.Drawing.Size(489, 29);
 			this.baseConfigPanel.TabIndex = 4;
 			// 
 			// tabMain
@@ -111,7 +112,7 @@
 			this.tabMain.Location = new System.Drawing.Point(0, 0);
 			this.tabMain.Name = "tabMain";
 			this.tabMain.SelectedIndex = 0;
-			this.tabMain.Size = new System.Drawing.Size(445, 290);
+			this.tabMain.Size = new System.Drawing.Size(489, 290);
 			this.tabMain.TabIndex = 2;
 			// 
 			// tpgGeneral
@@ -525,7 +526,7 @@
 			this.tpgAdvanced.Location = new System.Drawing.Point(4, 22);
 			this.tpgAdvanced.Name = "tpgAdvanced";
 			this.tpgAdvanced.Padding = new System.Windows.Forms.Padding(3);
-			this.tpgAdvanced.Size = new System.Drawing.Size(437, 264);
+			this.tpgAdvanced.Size = new System.Drawing.Size(481, 264);
 			this.tpgAdvanced.TabIndex = 3;
 			this.tpgAdvanced.Text = "Advanced";
 			this.tpgAdvanced.UseVisualStyleBackColor = true;
@@ -535,6 +536,7 @@
 			this.tableLayoutPanel2.ColumnCount = 2;
 			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.Controls.Add(this.chkAllowInvalidInput, 0, 3);
 			this.tableLayoutPanel2.Controls.Add(this.chkEnableRandomPowerOnState, 0, 1);
 			this.tableLayoutPanel2.Controls.Add(this.cboRamPowerOnState, 1, 0);
 			this.tableLayoutPanel2.Controls.Add(this.lblRamPowerOnState, 0, 0);
@@ -542,13 +544,24 @@
 			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 3);
 			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			this.tableLayoutPanel2.RowCount = 4;
+			this.tableLayoutPanel2.RowCount = 5;
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Size = new System.Drawing.Size(431, 258);
+			this.tableLayoutPanel2.Size = new System.Drawing.Size(475, 258);
 			this.tableLayoutPanel2.TabIndex = 5;
+			// 
+			// chkAllowInvalidInput
+			// 
+			this.chkAllowInvalidInput.Checked = false;
+			this.tableLayoutPanel2.SetColumnSpan(this.chkAllowInvalidInput, 2);
+			this.chkAllowInvalidInput.Location = new System.Drawing.Point(0, 75);
+			this.chkAllowInvalidInput.Name = "chkAllowInvalidInput";
+			this.chkAllowInvalidInput.Size = new System.Drawing.Size(447, 24);
+			this.chkAllowInvalidInput.TabIndex = 8;
+			this.chkAllowInvalidInput.Text = "Allow invalid input (e.g Down + Up or Left + Right at the same time)";
 			// 
 			// chkEnableRandomPowerOnState
 			// 
@@ -818,7 +831,7 @@
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(445, 319);
+			this.ClientSize = new System.Drawing.Size(489, 319);
 			this.Controls.Add(this.tabMain);
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
 			this.MaximizeBox = false;
@@ -911,5 +924,6 @@
 	  private System.Windows.Forms.RadioButton radBsxCustomTime;
 	  private System.Windows.Forms.DateTimePicker dtpBsxCustomTime;
 	  private System.Windows.Forms.DateTimePicker dtpBsxCustomDate;
+	  private Controls.ctrlRiskyOption chkAllowInvalidInput;
    }
 }

--- a/UI/Forms/Config/frmEmulationConfig.cs
+++ b/UI/Forms/Config/frmEmulationConfig.cs
@@ -33,6 +33,7 @@ namespace Mesen.GUI.Forms.Config
 			AddBinding(nameof(EmulationConfig.RamPowerOnState), cboRamPowerOnState);
 			AddBinding(nameof(EmulationConfig.EnableRandomPowerOnState), chkEnableRandomPowerOnState);
 			AddBinding(nameof(EmulationConfig.EnableStrictBoardMappings), chkEnableStrictBoardMappings);
+			AddBinding(nameof(EmulationConfig.AllowInvalidInput), chkAllowInvalidInput);
 
 			AddBinding(nameof(EmulationConfig.PpuExtraScanlinesBeforeNmi), nudExtraScanlinesBeforeNmi);
 			AddBinding(nameof(EmulationConfig.PpuExtraScanlinesAfterNmi), nudExtraScanlinesAfterNmi);


### PR DESCRIPTION
This adds a setting to the Advanced Emulation settings to allow L+R/U+D, and disables it by default, to match the behavior of Mesen.

![image](https://user-images.githubusercontent.com/5677090/146660215-c0575082-6837-4e14-9e8d-fc0c143e00d4.png)

