### PR TITLE
Add SDL2 include path to InteropDLL target.

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -2,7 +2,7 @@ name: "Linux build"
 on: push
 
 jobs:
-  win-build:
+  linux-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/makefile
+++ b/makefile
@@ -139,7 +139,7 @@ Linux/$(OBJFOLDER)/%.o: Linux/%.cpp
 Linux/$(OBJFOLDER)/%.o: Linux/libevdev/%.c
 	mkdir -p Linux/$(OBJFOLDER) && cd Linux/$(OBJFOLDER) && $(CC) $(CCOPTIONS) -c $(patsubst Linux/%, ../%, $<)
 InteropDLL/$(OBJFOLDER)/%.o: InteropDLL/%.cpp
-	mkdir -p InteropDLL/$(OBJFOLDER) && cd InteropDLL/$(OBJFOLDER) && $(CPPC) $(GCCOPTIONS)  -c $(patsubst InteropDLL/%, ../%, $<)
+	mkdir -p InteropDLL/$(OBJFOLDER) && cd InteropDLL/$(OBJFOLDER) && $(CPPC) $(GCCOPTIONS)  -c $(patsubst InteropDLL/%, ../%, $<) $(SDL2INC)
 	
 InteropDLL/$(OBJFOLDER)/$(SHAREDLIB): $(SEVENZIPOBJ) $(LUAOBJ) $(UTILOBJ) $(COREOBJ) $(LIBEVDEVOBJ) $(LINUXOBJ) $(DLLOBJ)
 	mkdir -p bin


### PR DESCRIPTION
This fixes builds on latest Ubuntu.