### PR TITLE
Fix Auto Joypad Poll address label

### DIFF
--- a/UI/Debugger/PpuViewer/frmRegisterViewer.cs
+++ b/UI/Debugger/PpuViewer/frmRegisterViewer.cs
@@ -809,7 +809,7 @@ namespace Mesen.GUI.Debugger
 				new RegEntry("$4200.7", "NMI Enabled", regs.EnableNmi),
 				new RegEntry("$4200.5", "V IRQ Enabled", regs.EnableVerticalIrq),
 				new RegEntry("$4200.4", "H IRQ Enabled", regs.EnableHorizontalIrq),
-				new RegEntry("$4200.1", "Auto Joypad Poll", regs.EnableAutoJoypadRead),
+				new RegEntry("$4200.0", "Auto Joypad Poll", regs.EnableAutoJoypadRead),
 
 				new RegEntry("$4201", "IO Port", regs.IoPortOutput, Format.X8),
 


### PR DESCRIPTION
Just a typo in one of the register viewer labels.