### PR TITLE
Added support for Source View when using WLA-DX .sym files

### DIFF
--- a/Docs/content/debugging/DebuggerIntegration.md
+++ b/Docs/content/debugging/DebuggerIntegration.md
@@ -20,16 +20,10 @@ To import the .DBG file, use the **<kbd>File&rarr;Workspace&rarr;Import Labels</
 You can also enable the `Automatically load DBG/MSL debug symbols` option in **<kbd>File&rarr;Import/Export&rarr;Integration Settings</kbd>** to make Mesen-S load any .DBG file it finds next to the ROM whenever the debugger is opened.  
 **Note:** For this option to work, the ROM file must have the same name as the DBG file (e.g `MyRom.sfc` and `MyRom.dbg`) and be inside the same folder.
 
-#### Source View ####
+### WLA-DX ###
 
-<div class="imgBox"><div>
-	<img src="/images/SourceView.png" />
-	<span>Source View</span>
-</div></div>
-
-When a .DBG file is loaded, an additional option appears in the code window's right-click menu:
-
-* **Switch to Source View**: This turns on `Source View` mode, which allows you to debug the game using the original code files, rather than the disassembly.  This can be used for both assembly and C projects.
+Integration with WLA-DX is possible via `.sym` files.
+When the `Automatically load DBG/MSL debug symbols` option in **<kbd>File&rarr;Import/Export&rarr;Integration Settings</kbd>** is enabled, the debugger will automatically attempt to load `.sym` files with the same name as the ROM (e.g `MyRom.sfc` and `MyRom.sym`)
 
 ### bass ###
 
@@ -40,6 +34,19 @@ When the `Automatically load DBG/MSL debug symbols` option in **<kbd>File&rarr;I
 
 Integration with RGBDS (for Game Boy projects) is possible via the `.sym` files that RGBDS produces.
 When the `Automatically load DBG/MSL debug symbols` option in **<kbd>File&rarr;Import/Export&rarr;Integration Settings</kbd>** is enabled, the debugger will automatically attempt to load `.sym` files with the same name as the ROM (e.g `MyRom.sfc` and `MyRom.sym`)
+
+#### Source View ####
+
+<div class="imgBox"><div>
+	<img src="/images/SourceView.png" />
+	<span>Source View</span>
+</div></div>
+
+When certain types of symbol files are loaded, an additional option appears in the code window's right-click menu:
+
+* **Switch to Source View**: This turns on `Source View` mode, which allows you to debug the game using the original code files, rather than the disassembly.  This can be used for both assembly and C projects.
+
+Currently, this feature is supported for .DBG files and WLA-DX .SYM files.
 
 ## Importing and exporting labels ##
 

--- a/UI/Debugger/Controls/ctrlDisassemblyView.cs
+++ b/UI/Debugger/Controls/ctrlDisassemblyView.cs
@@ -244,6 +244,13 @@ namespace Mesen.GUI.Debugger.Controls
 			if(prgAddress >= 0) {
 				ScrollToAddress((uint)prgAddress);
 			}
+
+			if (_inSourceView) {
+				mnuSwitchView.Text = "Switch to Disassembly View";
+			}
+			else { 
+				mnuSwitchView.Text = "Switch to Source View";
+			}
 		}
 
 		public void SetActiveAddress(int? address)

--- a/UI/Debugger/Integration/DbgImporter.cs
+++ b/UI/Debugger/Integration/DbgImporter.cs
@@ -100,26 +100,6 @@ namespace Mesen.GUI.Debugger.Integration
 			return null;
 		}
 
-		public string GetSourceCodeLine(int prgRomAddress)
-		{
-			if(prgRomAddress >= 0) {
-				try {
-					SourceCodeLocation line;
-					if(_linesByPrgAddress.TryGetValue(prgRomAddress, out line)) {
-						string output = "";
-						SourceFileInfo file = line.File;
-						if(file.Data == null) {
-							return string.Empty;
-						}
-
-						output += file.Data[line.LineNumber];
-						return output;
-					}
-				} catch { }
-			}
-			return null;
-		}
-
 		private SourceCodeLocation GetReferenceInfo(int referenceId)
 		{
 			FileInfo file;

--- a/UI/Debugger/Integration/ISymbolProvider.cs
+++ b/UI/Debugger/Integration/ISymbolProvider.cs
@@ -12,7 +12,6 @@ namespace Mesen.GUI.Debugger.Integration
 		List<SourceFileInfo> SourceFiles { get; }
 
 		AddressInfo? GetLineAddress(SourceFileInfo file, int lineIndex);
-		string GetSourceCodeLine(int prgRomAddress);
 		SourceCodeLocation GetSourceCodeLineInfo(AddressInfo address);
 		AddressInfo? GetSymbolAddressInfo(SourceSymbol symbol);
 		SourceCodeLocation GetSymbolDefinition(SourceSymbol symbol);

--- a/UI/Debugger/Workspace/DebugWorkspaceManager.cs
+++ b/UI/Debugger/Workspace/DebugWorkspaceManager.cs
@@ -160,7 +160,13 @@ namespace Mesen.GUI.Debugger.Workspace
 			string symContent = File.ReadAllText(symPath);
 			if(symContent.Contains("[labels]")) {
 				//Assume WLA-DX symbol files
-				new WlaDxImporter().Import(symPath, silent);
+				_symbolProvider = null;
+				_symbolProvider = new WlaDxImporter();
+				(_symbolProvider as WlaDxImporter).Import(symPath, silent);
+				SymbolProviderChanged?.Invoke(_symbolProvider);
+				LabelManager.RefreshLabels();
+
+				SymbolProviderChanged?.Invoke(_symbolProvider);
 			} else {
 				RomInfo romInfo = EmuApi.GetRomInfo();
 				if(romInfo.CoprocessorType == CoprocessorType.Gameboy || romInfo.CoprocessorType == CoprocessorType.SGB) {
@@ -172,8 +178,8 @@ namespace Mesen.GUI.Debugger.Workspace
 				} else {
 					BassLabelFile.Import(symPath, silent);
 				}
+				LabelManager.RefreshLabels();
 			}
-			LabelManager.RefreshLabels();
 		}
 
 		public static void ImportDbgFile(string dbgPath, bool silent = false)


### PR DESCRIPTION
This pull request enables the Source View of Mesen-S when using .sym files in the WLA-DX format.

Tested via .sym files produced by Asar using the WLA symbol files option. Currently, only the original version of WLA-DX .sym files is supported, not the newer v2 version. I couldn't figure out how to get the newest WLA-DX version to export "addr-to-line mappings" at all, so I wasn't able to test that format and thus decided not to implement it at this time.

Generally speaking, the Source View's capabilities are rather limited when using .sym files and might be inaccurate in certain cases, but I think it's still a gain over not having a source view at all.

![Source View Screenshot](https://puu.sh/IKrqV/8567ceed08.png)