### PR TITLE
Add new Feature: Custom background color in sprite viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.sln.docstates
 .vs/*
+*.cd
 
 # Build results
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -381,6 +381,9 @@
     <ClCompile Include="VideoRenderer.cpp" />
     <ClCompile Include="WaveRecorder.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ClassDiagram.cd" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1067,4 +1067,7 @@
       <UniqueIdentifier>{50d3ab3e-f393-4fa3-a8a6-8ec593089f1b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ClassDiagram.cd" />
+  </ItemGroup>
 </Project>

--- a/Core/PpuTools.cpp
+++ b/Core/PpuTools.cpp
@@ -110,7 +110,7 @@ void PpuTools::GetTileView(GetTileViewOptions options, uint8_t *source, uint32_t
 		for(int column = 0; column < options.Width; column++) {
 			uint32_t addr = baseOffset + bytesPerTile * column;
 
-			int baseOutputOffset;				
+			int baseOutputOffset;
 			if(options.Layout == TileLayout::SingleLine8x16) {
 				int displayColumn = column / 2 + ((row & 0x01) ? options.Width/2 : 0);
 				int displayRow = (row & ~0x01) + ((column & 0x01) ? 1 : 0);
@@ -257,7 +257,12 @@ static constexpr uint8_t _oamSizes[8][2][2] = {
 	{ { 2, 4 }, { 4, 4 } }  //16x32 + 32x32
 };
 
-void PpuTools::GetSpritePreview(GetSpritePreviewOptions options, PpuState state, uint8_t *vram, uint8_t *oamRam, uint8_t *cgram, uint32_t *outBuffer)
+void PpuTools::GetSpritePreview(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t* oamRam, uint8_t* cgram, uint32_t *outBuffer)
+{
+	GetSpritePreviewWithBackgroundColor(options, state, vram, oamRam, cgram, 0xFF888888, outBuffer);
+}
+
+void PpuTools::GetSpritePreviewWithBackgroundColor(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t* oamRam, uint8_t* cgram, uint32_t backgroundColor, uint32_t *outBuffer)
 {
 	//TODO
 	//uint16_t baseAddr = state.EnableOamPriority ? (_internalOamAddress & 0x1FC) : 0;
@@ -265,7 +270,7 @@ void PpuTools::GetSpritePreview(GetSpritePreviewOptions options, PpuState state,
 
 	bool filled[256 * 240] = {};
 	int lastScanline = state.OverscanMode ? 239 : 224;
-	std::fill(outBuffer, outBuffer + 256 * lastScanline, 0xFF888888);
+	std::fill(outBuffer, outBuffer + 256 * lastScanline, backgroundColor);
 	std::fill(outBuffer + 256 * lastScanline, outBuffer + 256 * 240, 0xFF000000);
 
 	for(int screenY = 0; screenY < lastScanline; screenY++) {
@@ -306,7 +311,7 @@ void PpuTools::GetSpritePreview(GetSpritePreviewOptions options, PpuState state,
 			//uint8_t priority = (flags >> 4) & 0x03;
 			bool horizontalMirror = (flags & 0x40) != 0;
 			bool verticalMirror = (flags & 0x80) != 0;
-			
+
 			uint8_t yOffset;
 			int rowOffset;
 

--- a/Core/PpuTools.h
+++ b/Core/PpuTools.h
@@ -33,10 +33,11 @@ public:
 	void GetTileView(GetTileViewOptions options, uint8_t *source, uint32_t srcSize, uint8_t *cgram, uint32_t *outBuffer);
 	void GetTilemap(GetTilemapOptions options, PpuState state, uint8_t* vram, uint8_t* cgram, uint32_t *outBuffer);
 	void GetSpritePreview(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t* oamRam, uint8_t* cgram, uint32_t *outBuffer);
+	void GetSpritePreviewWithBackgroundColor(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t* oamRam, uint8_t* cgram, uint32_t backgroundColor, uint32_t *outBuffer);
 
 	void SetViewerUpdateTiming(uint32_t viewerId, uint16_t scanline, uint16_t cycle, CpuType cpuType);
 	void RemoveViewer(uint32_t viewerId);
-	
+
 	__forceinline void UpdateViewers(uint16_t scanline, uint16_t cycle, CpuType cpuType)
 	{
 		if(_updateTimings.size() > 0) {

--- a/InteropDLL/DebugApiWrapper.cpp
+++ b/InteropDLL/DebugApiWrapper.cpp
@@ -101,14 +101,15 @@ extern "C"
 
 	DllExport void __stdcall ResetMemoryAccessCounts() { GetDebugger()->GetMemoryAccessCounter()->ResetCounts(); }
 	DllExport void __stdcall GetMemoryAccessCounts(uint32_t offset, uint32_t length, SnesMemoryType memoryType, AddressCounters* counts) { GetDebugger()->GetMemoryAccessCounter()->GetAccessCounts(offset, length, memoryType, counts); }
-	
+
 	DllExport void __stdcall GetCdlData(uint32_t offset, uint32_t length, SnesMemoryType memoryType, uint8_t* cdlData) { GetDebugger()->GetCdlData(offset, length, memoryType, cdlData); }
 	DllExport void __stdcall SetCdlData(CpuType cpuType, uint8_t* cdlData, uint32_t length) { GetDebugger()->SetCdlData(cpuType, cdlData, length); }
 	DllExport void __stdcall MarkBytesAs(CpuType cpuType, uint32_t start, uint32_t end, uint8_t flags) { GetDebugger()->MarkBytesAs(cpuType, start, end, flags); }
-	
+
 	DllExport void __stdcall GetTilemap(GetTilemapOptions options, PpuState state, uint8_t *vram, uint8_t *cgram, uint32_t *buffer) { GetDebugger()->GetPpuTools()->GetTilemap(options, state, vram, cgram, buffer); }
 	DllExport void __stdcall GetTileView(GetTileViewOptions options, uint8_t *source, uint32_t srcSize, uint8_t *cgram, uint32_t *buffer) { GetDebugger()->GetPpuTools()->GetTileView(options, source, srcSize, cgram, buffer); }
 	DllExport void __stdcall GetSpritePreview(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t *oamRam, uint8_t *cgram, uint32_t *buffer) { GetDebugger()->GetPpuTools()->GetSpritePreview(options, state, vram, oamRam, cgram, buffer); }
+	DllExport void __stdcall GetSpritePreviewWithBackgroundColor(GetSpritePreviewOptions options, PpuState state, uint8_t* vram, uint8_t *oamRam, uint8_t *cgram, uint32_t backgroundColor, uint32_t *buffer) { GetDebugger()->GetPpuTools()->GetSpritePreviewWithBackgroundColor(options, state, vram, oamRam, cgram, backgroundColor, buffer); }
 	DllExport void __stdcall SetViewerUpdateTiming(uint32_t viewerId, uint16_t scanline, uint16_t cycle, CpuType cpuType) { GetDebugger()->GetPpuTools()->SetViewerUpdateTiming(viewerId, scanline, cycle, cpuType); }
 
 	DllExport void __stdcall GetGameboyTilemap(uint8_t* vram, GbPpuState state, uint16_t offset, uint32_t* buffer) { GetDebugger()->GetPpuTools()->GetGameboyTilemap(vram, state, offset, buffer); }
@@ -126,6 +127,6 @@ extern "C"
 	//DllExport void __stdcall DebugSetScriptTimeout(uint32_t timeout) { LuaScriptingContext::SetScriptTimeout(timeout); }
 
 	DllExport uint32_t __stdcall AssembleCode(CpuType cpuType, char* code, uint32_t startAddress, int16_t* assembledOutput) { return GetDebugger()->GetAssembler(cpuType)->AssembleCode(code, startAddress, assembledOutput); }
-	
+
 	DllExport void __stdcall SaveRomToDisk(char* filename, bool saveIpsFile, CdlStripOption cdlStripOption) { GetDebugger()->SaveRomToDisk(filename, saveIpsFile, cdlStripOption); }
 };

--- a/UI/Debugger/Config/SpriteViewerConfig.cs
+++ b/UI/Debugger/Config/SpriteViewerConfig.cs
@@ -25,6 +25,8 @@ namespace Mesen.GUI.Config
 		public bool HideOffscreenSprites = false;
 		public int RefreshScanline = 240;
 		public int RefreshCycle = 0;
+		public int[] CustomBackgroundColors = {};
+		public int CurrentCustomBackgroundColor = Color.FromArgb( 255, 128, 128, 128 ).ToArgb();
 
 		public RefreshSpeed AutoRefreshSpeed = RefreshSpeed.Low;
 

--- a/UI/Debugger/PpuViewer/frmSpriteViewer.Designer.cs
+++ b/UI/Debugger/PpuViewer/frmSpriteViewer.Designer.cs
@@ -27,246 +27,255 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.ctrlScanlineCycleSelect = new Mesen.GUI.Debugger.Controls.ctrlScanlineCycleSelect();
-			this.ctrlSplitContainer = new Mesen.GUI.Controls.ctrlSplitContainer();
-			this.ctrlImagePanel = new Mesen.GUI.Debugger.PpuViewer.ctrlImagePanel();
-			this.ctrlSpriteList = new Mesen.GUI.Debugger.PpuViewer.ctrlSpriteList();
-			this.ctrlMesenMenuStrip1 = new Mesen.GUI.Controls.ctrlMesenMenuStrip();
-			this.mnuFile = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuCopyToClipboard = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuSaveAsPng = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
-			this.mnuClose = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuView = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuAutoRefresh = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuAutoRefreshSpeed = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuAutoRefreshLow = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuAutoRefreshNormal = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuAutoRefreshHigh = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
-			this.mnuRefresh = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.mnuZoomIn = new System.Windows.Forms.ToolStripMenuItem();
-			this.mnuZoomOut = new System.Windows.Forms.ToolStripMenuItem();
-			((System.ComponentModel.ISupportInitialize)(this.ctrlSplitContainer)).BeginInit();
-			this.ctrlSplitContainer.Panel1.SuspendLayout();
-			this.ctrlSplitContainer.Panel2.SuspendLayout();
-			this.ctrlSplitContainer.SuspendLayout();
-			this.ctrlMesenMenuStrip1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// ctrlScanlineCycleSelect
-			// 
-			this.ctrlScanlineCycleSelect.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.ctrlScanlineCycleSelect.Location = new System.Drawing.Point(0, 512);
-			this.ctrlScanlineCycleSelect.Name = "ctrlScanlineCycleSelect";
-			this.ctrlScanlineCycleSelect.Size = new System.Drawing.Size(842, 28);
-			this.ctrlScanlineCycleSelect.TabIndex = 5;
-			// 
-			// ctrlSplitContainer
-			// 
-			this.ctrlSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ctrlSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-			this.ctrlSplitContainer.HidePanel2 = false;
-			this.ctrlSplitContainer.Location = new System.Drawing.Point(0, 24);
-			this.ctrlSplitContainer.Name = "ctrlSplitContainer";
-			// 
-			// ctrlSplitContainer.Panel1
-			// 
-			this.ctrlSplitContainer.Panel1.Controls.Add(this.ctrlImagePanel);
-			this.ctrlSplitContainer.Panel1MinSize = 256;
-			// 
-			// ctrlSplitContainer.Panel2
-			// 
-			this.ctrlSplitContainer.Panel2.Controls.Add(this.ctrlSpriteList);
-			this.ctrlSplitContainer.Panel2.Padding = new System.Windows.Forms.Padding(2, 0, 0, 0);
-			this.ctrlSplitContainer.Panel2MinSize = 100;
-			this.ctrlSplitContainer.Size = new System.Drawing.Size(842, 488);
-			this.ctrlSplitContainer.SplitterDistance = 512;
-			this.ctrlSplitContainer.TabIndex = 8;
-			// 
-			// ctrlImagePanel
-			// 
-			this.ctrlImagePanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ctrlImagePanel.GridSizeX = 0;
-			this.ctrlImagePanel.GridSizeY = 0;
-			this.ctrlImagePanel.Image = null;
-			this.ctrlImagePanel.ImageScale = 1;
-			this.ctrlImagePanel.ImageSize = new System.Drawing.Size(0, 0);
-			this.ctrlImagePanel.Location = new System.Drawing.Point(0, 0);
-			this.ctrlImagePanel.Name = "ctrlImagePanel";
-			this.ctrlImagePanel.Overlay = new System.Drawing.Rectangle(0, 0, 0, 0);
-			this.ctrlImagePanel.Selection = new System.Drawing.Rectangle(0, 0, 0, 0);
-			this.ctrlImagePanel.SelectionWrapPosition = 0;
-			this.ctrlImagePanel.Size = new System.Drawing.Size(512, 488);
-			this.ctrlImagePanel.TabIndex = 9;
-			this.ctrlImagePanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.ctrlImagePanel_MouseClick);
-			// 
-			// ctrlSpriteList
-			// 
-			this.ctrlSpriteList.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ctrlSpriteList.Location = new System.Drawing.Point(2, 0);
-			this.ctrlSpriteList.Name = "ctrlSpriteList";
-			this.ctrlSpriteList.Size = new System.Drawing.Size(324, 488);
-			this.ctrlSpriteList.TabIndex = 0;
-			this.ctrlSpriteList.SpriteSelected += new Mesen.GUI.Debugger.PpuViewer.ctrlSpriteList.SpriteSelectedHandler(this.ctrlSpriteList_SpriteSelected);
-			// 
-			// ctrlMesenMenuStrip1
-			// 
-			this.ctrlMesenMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ctrlScanlineCycleSelect = new Mesen.GUI.Debugger.Controls.ctrlScanlineCycleSelect();
+            this.ctrlSplitContainer = new Mesen.GUI.Controls.ctrlSplitContainer();
+            this.ctrlImagePanel = new Mesen.GUI.Debugger.PpuViewer.ctrlImagePanel();
+            this.ctrlSpriteList = new Mesen.GUI.Debugger.PpuViewer.ctrlSpriteList();
+            this.ctrlMesenMenuStrip1 = new Mesen.GUI.Controls.ctrlMesenMenuStrip();
+            this.mnuFile = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuCopyToClipboard = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuSaveAsPng = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
+            this.mnuClose = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuView = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuAutoRefresh = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuAutoRefreshSpeed = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuAutoRefreshLow = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuAutoRefreshNormal = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuAutoRefreshHigh = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.mnuRefresh = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.mnuZoomIn = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuZoomOut = new System.Windows.Forms.ToolStripMenuItem();
+            this.backgroundColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.ctrlSplitContainer)).BeginInit();
+            this.ctrlSplitContainer.Panel1.SuspendLayout();
+            this.ctrlSplitContainer.Panel2.SuspendLayout();
+            this.ctrlSplitContainer.SuspendLayout();
+            this.ctrlMesenMenuStrip1.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // ctrlScanlineCycleSelect
+            //
+            this.ctrlScanlineCycleSelect.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.ctrlScanlineCycleSelect.Location = new System.Drawing.Point(0, 512);
+            this.ctrlScanlineCycleSelect.Name = "ctrlScanlineCycleSelect";
+            this.ctrlScanlineCycleSelect.Size = new System.Drawing.Size(842, 28);
+            this.ctrlScanlineCycleSelect.TabIndex = 5;
+            //
+            // ctrlSplitContainer
+            //
+            this.ctrlSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ctrlSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.ctrlSplitContainer.HidePanel2 = false;
+            this.ctrlSplitContainer.Location = new System.Drawing.Point(0, 24);
+            this.ctrlSplitContainer.Name = "ctrlSplitContainer";
+            //
+            // ctrlSplitContainer.Panel1
+            //
+            this.ctrlSplitContainer.Panel1.Controls.Add(this.ctrlImagePanel);
+            this.ctrlSplitContainer.Panel1MinSize = 256;
+            //
+            // ctrlSplitContainer.Panel2
+            //
+            this.ctrlSplitContainer.Panel2.Controls.Add(this.ctrlSpriteList);
+            this.ctrlSplitContainer.Panel2.Padding = new System.Windows.Forms.Padding(2, 0, 0, 0);
+            this.ctrlSplitContainer.Panel2MinSize = 100;
+            this.ctrlSplitContainer.Size = new System.Drawing.Size(842, 488);
+            this.ctrlSplitContainer.SplitterDistance = 512;
+            this.ctrlSplitContainer.TabIndex = 8;
+            //
+            // ctrlImagePanel
+            //
+            this.ctrlImagePanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ctrlImagePanel.GridSizeX = 0;
+            this.ctrlImagePanel.GridSizeY = 0;
+            this.ctrlImagePanel.Image = null;
+            this.ctrlImagePanel.ImageScale = 1;
+            this.ctrlImagePanel.ImageSize = new System.Drawing.Size(0, 0);
+            this.ctrlImagePanel.Location = new System.Drawing.Point(0, 0);
+            this.ctrlImagePanel.Name = "ctrlImagePanel";
+            this.ctrlImagePanel.Overlay = new System.Drawing.Rectangle(0, 0, 0, 0);
+            this.ctrlImagePanel.Selection = new System.Drawing.Rectangle(0, 0, 0, 0);
+            this.ctrlImagePanel.SelectionWrapPosition = 0;
+            this.ctrlImagePanel.Size = new System.Drawing.Size(512, 488);
+            this.ctrlImagePanel.TabIndex = 9;
+            this.ctrlImagePanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.ctrlImagePanel_MouseClick);
+            //
+            // ctrlSpriteList
+            //
+            this.ctrlSpriteList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ctrlSpriteList.Location = new System.Drawing.Point(2, 0);
+            this.ctrlSpriteList.Name = "ctrlSpriteList";
+            this.ctrlSpriteList.Size = new System.Drawing.Size(324, 488);
+            this.ctrlSpriteList.TabIndex = 0;
+            this.ctrlSpriteList.SpriteSelected += new Mesen.GUI.Debugger.PpuViewer.ctrlSpriteList.SpriteSelectedHandler(this.ctrlSpriteList_SpriteSelected);
+            //
+            // ctrlMesenMenuStrip1
+            //
+            this.ctrlMesenMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuFile,
             this.mnuView});
-			this.ctrlMesenMenuStrip1.Location = new System.Drawing.Point(0, 0);
-			this.ctrlMesenMenuStrip1.Name = "ctrlMesenMenuStrip1";
-			this.ctrlMesenMenuStrip1.Size = new System.Drawing.Size(842, 24);
-			this.ctrlMesenMenuStrip1.TabIndex = 8;
-			this.ctrlMesenMenuStrip1.Text = "ctrlMesenMenuStrip1";
-			// 
-			// mnuFile
-			// 
-			this.mnuFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ctrlMesenMenuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.ctrlMesenMenuStrip1.Name = "ctrlMesenMenuStrip1";
+            this.ctrlMesenMenuStrip1.Size = new System.Drawing.Size(842, 24);
+            this.ctrlMesenMenuStrip1.TabIndex = 8;
+            this.ctrlMesenMenuStrip1.Text = "ctrlMesenMenuStrip1";
+            //
+            // mnuFile
+            //
+            this.mnuFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuCopyToClipboard,
             this.mnuSaveAsPng,
             this.toolStripMenuItem3,
             this.mnuClose});
-			this.mnuFile.Name = "mnuFile";
-			this.mnuFile.Size = new System.Drawing.Size(37, 20);
-			this.mnuFile.Text = "File";
-			// 
-			// mnuCopyToClipboard
-			// 
-			this.mnuCopyToClipboard.Image = global::Mesen.GUI.Properties.Resources.Copy;
-			this.mnuCopyToClipboard.Name = "mnuCopyToClipboard";
-			this.mnuCopyToClipboard.Size = new System.Drawing.Size(169, 22);
-			this.mnuCopyToClipboard.Text = "Copy to clipboard";
-			// 
-			// mnuSaveAsPng
-			// 
-			this.mnuSaveAsPng.Image = global::Mesen.GUI.Properties.Resources.Export;
-			this.mnuSaveAsPng.Name = "mnuSaveAsPng";
-			this.mnuSaveAsPng.Size = new System.Drawing.Size(169, 22);
-			this.mnuSaveAsPng.Text = "Save as PNG";
-			// 
-			// toolStripMenuItem3
-			// 
-			this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-			this.toolStripMenuItem3.Size = new System.Drawing.Size(166, 6);
-			// 
-			// mnuClose
-			// 
-			this.mnuClose.Image = global::Mesen.GUI.Properties.Resources.Exit;
-			this.mnuClose.Name = "mnuClose";
-			this.mnuClose.Size = new System.Drawing.Size(169, 22);
-			this.mnuClose.Text = "Close";
-			this.mnuClose.Click += new System.EventHandler(this.mnuClose_Click);
-			// 
-			// mnuView
-			// 
-			this.mnuView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuFile.Name = "mnuFile";
+            this.mnuFile.Size = new System.Drawing.Size(37, 20);
+            this.mnuFile.Text = "File";
+            //
+            // mnuCopyToClipboard
+            //
+            this.mnuCopyToClipboard.Image = global::Mesen.GUI.Properties.Resources.Copy;
+            this.mnuCopyToClipboard.Name = "mnuCopyToClipboard";
+            this.mnuCopyToClipboard.Size = new System.Drawing.Size(169, 22);
+            this.mnuCopyToClipboard.Text = "Copy to clipboard";
+            //
+            // mnuSaveAsPng
+            //
+            this.mnuSaveAsPng.Image = global::Mesen.GUI.Properties.Resources.Export;
+            this.mnuSaveAsPng.Name = "mnuSaveAsPng";
+            this.mnuSaveAsPng.Size = new System.Drawing.Size(169, 22);
+            this.mnuSaveAsPng.Text = "Save as PNG";
+            //
+            // toolStripMenuItem3
+            //
+            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(166, 6);
+            //
+            // mnuClose
+            //
+            this.mnuClose.Image = global::Mesen.GUI.Properties.Resources.Exit;
+            this.mnuClose.Name = "mnuClose";
+            this.mnuClose.Size = new System.Drawing.Size(169, 22);
+            this.mnuClose.Text = "Close";
+            this.mnuClose.Click += new System.EventHandler(this.mnuClose_Click);
+            //
+            // mnuView
+            //
+            this.mnuView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuAutoRefresh,
             this.mnuAutoRefreshSpeed,
             this.toolStripMenuItem2,
             this.mnuRefresh,
             this.toolStripMenuItem1,
             this.mnuZoomIn,
-            this.mnuZoomOut});
-			this.mnuView.Name = "mnuView";
-			this.mnuView.Size = new System.Drawing.Size(44, 20);
-			this.mnuView.Text = "View";
-			// 
-			// mnuAutoRefresh
-			// 
-			this.mnuAutoRefresh.Checked = true;
-			this.mnuAutoRefresh.CheckOnClick = true;
-			this.mnuAutoRefresh.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.mnuAutoRefresh.Name = "mnuAutoRefresh";
-			this.mnuAutoRefresh.Size = new System.Drawing.Size(176, 22);
-			this.mnuAutoRefresh.Text = "Auto-refresh";
-			this.mnuAutoRefresh.CheckedChanged += new System.EventHandler(this.mnuAutoRefresh_CheckedChanged);
-			// 
-			// mnuAutoRefreshSpeed
-			// 
-			this.mnuAutoRefreshSpeed.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuZoomOut,
+            this.backgroundColorToolStripMenuItem});
+            this.mnuView.Name = "mnuView";
+            this.mnuView.Size = new System.Drawing.Size(44, 20);
+            this.mnuView.Text = "View";
+            //
+            // mnuAutoRefresh
+            //
+            this.mnuAutoRefresh.Checked = true;
+            this.mnuAutoRefresh.CheckOnClick = true;
+            this.mnuAutoRefresh.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.mnuAutoRefresh.Name = "mnuAutoRefresh";
+            this.mnuAutoRefresh.Size = new System.Drawing.Size(176, 22);
+            this.mnuAutoRefresh.Text = "Auto-refresh";
+            this.mnuAutoRefresh.CheckedChanged += new System.EventHandler(this.mnuAutoRefresh_CheckedChanged);
+            //
+            // mnuAutoRefreshSpeed
+            //
+            this.mnuAutoRefreshSpeed.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuAutoRefreshLow,
             this.mnuAutoRefreshNormal,
             this.mnuAutoRefreshHigh});
-			this.mnuAutoRefreshSpeed.Image = global::Mesen.GUI.Properties.Resources.Speed;
-			this.mnuAutoRefreshSpeed.Name = "mnuAutoRefreshSpeed";
-			this.mnuAutoRefreshSpeed.Size = new System.Drawing.Size(176, 22);
-			this.mnuAutoRefreshSpeed.Text = "Auto-refresh Speed";
-			// 
-			// mnuAutoRefreshLow
-			// 
-			this.mnuAutoRefreshLow.Name = "mnuAutoRefreshLow";
-			this.mnuAutoRefreshLow.Size = new System.Drawing.Size(159, 22);
-			this.mnuAutoRefreshLow.Text = "Low (15 FPS)";
-			// 
-			// mnuAutoRefreshNormal
-			// 
-			this.mnuAutoRefreshNormal.Name = "mnuAutoRefreshNormal";
-			this.mnuAutoRefreshNormal.Size = new System.Drawing.Size(159, 22);
-			this.mnuAutoRefreshNormal.Text = "Normal (30 FPS)";
-			// 
-			// mnuAutoRefreshHigh
-			// 
-			this.mnuAutoRefreshHigh.Name = "mnuAutoRefreshHigh";
-			this.mnuAutoRefreshHigh.Size = new System.Drawing.Size(159, 22);
-			this.mnuAutoRefreshHigh.Text = "High (60 FPS)";
-			// 
-			// toolStripMenuItem2
-			// 
-			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-			this.toolStripMenuItem2.Size = new System.Drawing.Size(173, 6);
-			// 
-			// mnuRefresh
-			// 
-			this.mnuRefresh.Image = global::Mesen.GUI.Properties.Resources.Refresh;
-			this.mnuRefresh.Name = "mnuRefresh";
-			this.mnuRefresh.Size = new System.Drawing.Size(176, 22);
-			this.mnuRefresh.Text = "Refresh";
-			this.mnuRefresh.Click += new System.EventHandler(this.mnuRefresh_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(173, 6);
-			// 
-			// mnuZoomIn
-			// 
-			this.mnuZoomIn.Name = "mnuZoomIn";
-			this.mnuZoomIn.Size = new System.Drawing.Size(176, 22);
-			this.mnuZoomIn.Text = "Zoom In";
-			this.mnuZoomIn.Click += new System.EventHandler(this.mnuZoomIn_Click);
-			// 
-			// mnuZoomOut
-			// 
-			this.mnuZoomOut.Name = "mnuZoomOut";
-			this.mnuZoomOut.Size = new System.Drawing.Size(176, 22);
-			this.mnuZoomOut.Text = "Zoom Out";
-			this.mnuZoomOut.Click += new System.EventHandler(this.mnuZoomOut_Click);
-			// 
-			// frmSpriteViewer
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(842, 540);
-			this.Controls.Add(this.ctrlSplitContainer);
-			this.Controls.Add(this.ctrlScanlineCycleSelect);
-			this.Controls.Add(this.ctrlMesenMenuStrip1);
-			this.MainMenuStrip = this.ctrlMesenMenuStrip1;
-			this.Name = "frmSpriteViewer";
-			this.Text = "Sprite Viewer";
-			this.Controls.SetChildIndex(this.ctrlMesenMenuStrip1, 0);
-			this.Controls.SetChildIndex(this.ctrlScanlineCycleSelect, 0);
-			this.Controls.SetChildIndex(this.ctrlSplitContainer, 0);
-			this.ctrlSplitContainer.Panel1.ResumeLayout(false);
-			this.ctrlSplitContainer.Panel2.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.ctrlSplitContainer)).EndInit();
-			this.ctrlSplitContainer.ResumeLayout(false);
-			this.ctrlMesenMenuStrip1.ResumeLayout(false);
-			this.ctrlMesenMenuStrip1.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.mnuAutoRefreshSpeed.Image = global::Mesen.GUI.Properties.Resources.Speed;
+            this.mnuAutoRefreshSpeed.Name = "mnuAutoRefreshSpeed";
+            this.mnuAutoRefreshSpeed.Size = new System.Drawing.Size(176, 22);
+            this.mnuAutoRefreshSpeed.Text = "Auto-refresh Speed";
+            //
+            // mnuAutoRefreshLow
+            //
+            this.mnuAutoRefreshLow.Name = "mnuAutoRefreshLow";
+            this.mnuAutoRefreshLow.Size = new System.Drawing.Size(159, 22);
+            this.mnuAutoRefreshLow.Text = "Low (15 FPS)";
+            //
+            // mnuAutoRefreshNormal
+            //
+            this.mnuAutoRefreshNormal.Name = "mnuAutoRefreshNormal";
+            this.mnuAutoRefreshNormal.Size = new System.Drawing.Size(159, 22);
+            this.mnuAutoRefreshNormal.Text = "Normal (30 FPS)";
+            //
+            // mnuAutoRefreshHigh
+            //
+            this.mnuAutoRefreshHigh.Name = "mnuAutoRefreshHigh";
+            this.mnuAutoRefreshHigh.Size = new System.Drawing.Size(159, 22);
+            this.mnuAutoRefreshHigh.Text = "High (60 FPS)";
+            //
+            // toolStripMenuItem2
+            //
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(173, 6);
+            //
+            // mnuRefresh
+            //
+            this.mnuRefresh.Image = global::Mesen.GUI.Properties.Resources.Refresh;
+            this.mnuRefresh.Name = "mnuRefresh";
+            this.mnuRefresh.Size = new System.Drawing.Size(176, 22);
+            this.mnuRefresh.Text = "Refresh";
+            this.mnuRefresh.Click += new System.EventHandler(this.mnuRefresh_Click);
+            //
+            // toolStripMenuItem1
+            //
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(173, 6);
+            //
+            // mnuZoomIn
+            //
+            this.mnuZoomIn.Name = "mnuZoomIn";
+            this.mnuZoomIn.Size = new System.Drawing.Size(176, 22);
+            this.mnuZoomIn.Text = "Zoom In";
+            this.mnuZoomIn.Click += new System.EventHandler(this.mnuZoomIn_Click);
+            //
+            // mnuZoomOut
+            //
+            this.mnuZoomOut.Name = "mnuZoomOut";
+            this.mnuZoomOut.Size = new System.Drawing.Size(176, 22);
+            this.mnuZoomOut.Text = "Zoom Out";
+            this.mnuZoomOut.Click += new System.EventHandler(this.mnuZoomOut_Click);
+            //
+            // backgroundColorToolStripMenuItem
+            //
+            this.backgroundColorToolStripMenuItem.Name = "backgroundColorToolStripMenuItem";
+            this.backgroundColorToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.backgroundColorToolStripMenuItem.Text = "Background Color";
+            this.backgroundColorToolStripMenuItem.Click += new System.EventHandler(this.UpdateBackgroundColor);
+            //
+            // frmSpriteViewer
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(842, 540);
+            this.Controls.Add(this.ctrlSplitContainer);
+            this.Controls.Add(this.ctrlScanlineCycleSelect);
+            this.Controls.Add(this.ctrlMesenMenuStrip1);
+            this.MainMenuStrip = this.ctrlMesenMenuStrip1;
+            this.Name = "frmSpriteViewer";
+            this.Text = "Sprite Viewer";
+            this.Controls.SetChildIndex(this.ctrlMesenMenuStrip1, 0);
+            this.Controls.SetChildIndex(this.ctrlScanlineCycleSelect, 0);
+            this.Controls.SetChildIndex(this.ctrlSplitContainer, 0);
+            this.ctrlSplitContainer.Panel1.ResumeLayout(false);
+            this.ctrlSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.ctrlSplitContainer)).EndInit();
+            this.ctrlSplitContainer.ResumeLayout(false);
+            this.ctrlMesenMenuStrip1.ResumeLayout(false);
+            this.ctrlMesenMenuStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -292,5 +301,6 @@
 		private System.Windows.Forms.ToolStripMenuItem mnuAutoRefreshLow;
 		private System.Windows.Forms.ToolStripMenuItem mnuAutoRefreshNormal;
 		private System.Windows.Forms.ToolStripMenuItem mnuAutoRefreshHigh;
-	}
+	  private System.Windows.Forms.ToolStripMenuItem backgroundColorToolStripMenuItem;
+   }
 }

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -104,6 +104,7 @@ namespace Mesen.GUI
 		[DllImport(DllPath)] public static extern void GetTilemap(GetTilemapOptions options, PpuState state, byte[] vram, byte[] cgram, [In, Out] byte[] buffer);
 		[DllImport(DllPath)] public static extern void GetTileView(GetTileViewOptions options, byte[] source, int srcSize, byte[] cgram, [In, Out] byte[] buffer);
 		[DllImport(DllPath)] public static extern void GetSpritePreview(GetSpritePreviewOptions options, PpuState state, byte[] vram, byte[] oamRam, byte[] cgram, [In, Out] byte[] buffer);
+		[DllImport(DllPath)] public static extern void GetSpritePreviewWithBackgroundColor(GetSpritePreviewOptions options, PpuState state, byte[] vram, byte[] oamRam, byte[] cgram, int backgroundColor, [In, Out] byte[] buffer);
 
 		[DllImport(DllPath)] public static extern void GetGameboyTilemap(byte[] vram, GbPpuState state, UInt16 offset, [In, Out] byte[] buffer);
 		[DllImport(DllPath)] public static extern void GetGameboySpritePreview(GetSpritePreviewOptions options, GbPpuState state, byte[] vram, byte[] oamRam, [In, Out] byte[] buffer);
@@ -127,7 +128,7 @@ namespace Mesen.GUI
 		}
 
 		[DllImport(DllPath)] public static extern void GetEventViewerEvent(CpuType cpuType, ref DebugEventInfo evtInfo, UInt16 scanline, UInt16 cycle, EventViewerDisplayOptions options);
-		[DllImport(DllPath)] public static extern UInt32 TakeEventSnapshot(CpuType cpuType, EventViewerDisplayOptions options);		
+		[DllImport(DllPath)] public static extern UInt32 TakeEventSnapshot(CpuType cpuType, EventViewerDisplayOptions options);
 
 		[DllImport(DllPath, EntryPoint = "GetEventViewerOutput")] private static extern void GetEventViewerOutputWrapper(CpuType cpuType, [In, Out]byte[] buffer, UInt32 bufferSize, EventViewerDisplayOptions options);
 		public static byte[] GetEventViewerOutput(CpuType cpuType, int scanlineWidth, UInt32 scanlineCount, EventViewerDisplayOptions options)
@@ -556,7 +557,7 @@ namespace Mesen.GUI
 		DivideBy0 = 3,
 		OutOfScope = 4
 	}
-	
+
 	public struct StackFrameInfo
 	{
 		public UInt32 Source;
@@ -572,7 +573,7 @@ namespace Mesen.GUI
 		Nmi = 1,
 		Irq = 2
 	}
-	
+
 	public enum CpuType : byte
 	{
 		Cpu,
@@ -639,7 +640,7 @@ namespace Mesen.GUI
 		BreakOnWdm = 5,
 		BreakOnStp = 6,
 		BreakOnUninitMemoryRead = 7,
-		
+
 		GbInvalidOamAccess = 8,
 		GbInvalidVramAccess = 9,
 		GbDisableLcdOutsideVblank = 10,


### PR DESCRIPTION
The background color in the sprite viewer is now customizable:

![mesen2](https://user-images.githubusercontent.com/2309875/164676487-34b7718c-7eb4-4b6b-8ce8-a08118e4d771.png)
![mesen3](https://user-images.githubusercontent.com/2309875/164677387-e2451ab1-9d22-440a-8137-d432be8b79db.png)

- Custom colors and the last selected color are persistent, aka, written to the config file. 
- The `PpuTools` class' interface in the C++ core has been slightly modified to add this feature.
- `.gitignore` has been updated to exclude Class Diagrams generated by Visual Studio.
