### PR TITLE
Ported cheat finder from Mesen-X

### DIFF
--- a/UI/Debugger/Controls/BaseScrollableTextboxUserControl.cs
+++ b/UI/Debugger/Controls/BaseScrollableTextboxUserControl.cs
@@ -1,0 +1,52 @@
+using System.Drawing;
+using Mesen.GUI.Controls;
+
+namespace Mesen.GUI.Debugger.Controls
+{
+	public class BaseScrollableTextboxUserControl : BaseControl
+	{
+		virtual protected ctrlScrollableTextbox ScrollableTextbox
+		{
+			get
+			{
+				return null;
+			}
+		}
+
+		public void OpenSearchBox()
+		{
+			this.ScrollableTextbox.OpenSearchBox();
+		}
+
+		public void FindNext()
+		{
+			this.ScrollableTextbox.FindNext();
+		}
+
+		public void FindPrevious()
+		{
+			this.ScrollableTextbox.FindPrevious();
+		}
+
+		public void ScrollToLineIndex(int lineIndex)
+		{
+			this.ScrollableTextbox.ScrollToLineIndex(lineIndex);
+		}
+
+		public bool HideSelection
+		{
+			get { return this.ScrollableTextbox.HideSelection; }
+			set { this.ScrollableTextbox.HideSelection = value; }
+		}
+
+		public int GetCurrentLine()
+		{
+			return this.ScrollableTextbox.CurrentLine;
+		}
+
+		public string GetWordUnderLocation(Point position)
+		{
+			return this.ScrollableTextbox.GetWordUnderLocation(position);
+		}
+	}
+}

--- a/UI/Debugger/Controls/ctrlAddressList.Designer.cs
+++ b/UI/Debugger/Controls/ctrlAddressList.Designer.cs
@@ -1,0 +1,81 @@
+namespace Mesen.GUI.Debugger.Controls
+{
+	partial class ctrlAddressList
+	{
+		/// <summary> 
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary> 
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing && (components != null)) {
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Component Designer generated code
+
+		/// <summary> 
+		/// Required method for Designer support - do not modify 
+		/// the contents of this method with the code editor.
+		///
+		/// Despite warnings, this method was changed manually :),
+		/// get rekt Designer.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.ctrlDataViewer = new ctrlScrollableTextbox();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// tableLayoutPanel1
+			// 
+			this.tableLayoutPanel1.ColumnCount = 1;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Controls.Add(this.ctrlDataViewer, 0, 1);
+			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 2;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(191, 109);
+			this.tableLayoutPanel1.TabIndex = 0;
+			// 
+			// ctrlDataViewer
+			// 
+			this.ctrlDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.ctrlDataViewer.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.ctrlDataViewer.Location = new System.Drawing.Point(3, 3);
+			this.ctrlDataViewer.Name = "ctrlDataViewer";
+			this.ctrlDataViewer.ShowContentNotes = false;
+			this.ctrlDataViewer.ShowLineNumberNotes = false;
+			this.ctrlDataViewer.Size = new System.Drawing.Size(185, 103);
+			this.ctrlDataViewer.TabIndex = 0;
+			// 
+			// ctrlAddressList
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.tableLayoutPanel1);
+			this.Name = "ctrlAddressList";
+			this.Size = new System.Drawing.Size(191, 109);
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+		private ctrlScrollableTextbox ctrlDataViewer;
+	}
+}

--- a/UI/Debugger/Controls/ctrlAddressList.cs
+++ b/UI/Debugger/Controls/ctrlAddressList.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Data;
+using System.Linq;
+
+namespace Mesen.GUI.Debugger.Controls
+{
+	public partial class ctrlAddressList : BaseScrollableTextboxUserControl
+	{
+		private int[] _addresses;
+		private int[] _values;
+
+		public ctrlAddressList()
+		{
+			InitializeComponent();
+		}
+
+		protected override ctrlScrollableTextbox ScrollableTextbox
+		{
+			get { return this.ctrlDataViewer; }
+		}
+
+		public event EventHandler SelectedLineChanged {
+			add {
+				this.ctrlDataViewer.SelectedLineChanged += value;
+			}
+			remove {
+				this.ctrlDataViewer.SelectedLineChanged -= value;
+			}
+		}
+
+		public int AddressSize { set { this.ctrlDataViewer.AddressSize = value; } }
+		public int MarginWidth { set { this.ctrlDataViewer.MarginWidth = value; } }
+
+		public void SetData(int[] values,int[] addresses, bool hex, int padding = -1)
+		{
+			this.ctrlDataViewer.DataProvider = new TraceLoggerCodeDataProvider(
+				values.Select((v) => hex ? "$" + v.ToString("X" + padding.ToString()) : v.ToString()).ToList(),
+				addresses.ToList(),
+				values.Select((v) => "").ToList(),
+				addresses.Select((a) => 0).ToList()
+			);
+			_addresses = addresses;
+			_values = values;
+		}
+
+		public int? CurrentAddress
+		{
+			get
+			{
+				if(this._addresses?.Length > 0 && this.ctrlDataViewer.SelectedLine >= 0 && this.ctrlDataViewer.SelectedLine < this._addresses.Length) {
+					return _addresses[_addresses.Length - this.ctrlDataViewer.SelectedLine - 1];
+				} else {
+					return null;
+				}
+			}
+		}
+
+		public int? CurrentValue
+		{
+			get
+			{
+				if(this._values?.Length > 0 && this.ctrlDataViewer.SelectedLine >= 0 && this.ctrlDataViewer.SelectedLine < this._values.Length) {
+					return _values[_values.Length - this.ctrlDataViewer.SelectedLine - 1];
+				} else {
+					return null;
+				}
+			}
+		}
+	}
+}

--- a/UI/Debugger/Controls/ctrlScrollableTextbox.cs
+++ b/UI/Debugger/Controls/ctrlScrollableTextbox.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using Mesen.GUI.Controls;
 using Mesen.GUI.Config;
-using System.Globalization;
 
 namespace Mesen.GUI.Debugger.Controls
 {
@@ -114,6 +108,15 @@ namespace Mesen.GUI.Debugger.Controls
 		private void ctrlTextbox_SelectedLineChanged(object sender, EventArgs e)
 		{
 			this.vScrollBar.Invalidate();
+		}
+
+		public event EventHandler SelectedLineChanged {
+			add {
+				this.ctrlTextbox.SelectedLineChanged += value;
+			}
+			remove {
+				this.ctrlTextbox.SelectedLineChanged -= value;
+			}
 		}
 
 		[Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/UI/Debugger/Labels/ctrlLabelList.cs
+++ b/UI/Debugger/Labels/ctrlLabelList.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Collections;
 using Mesen.GUI.Controls;
 using Mesen.GUI.Config;
 using Mesen.GUI.Forms;

--- a/UI/Debugger/Labels/ctrlLabelList.cs
+++ b/UI/Debugger/Labels/ctrlLabelList.cs
@@ -222,7 +222,6 @@ namespace Mesen.GUI.Debugger.Controls
 		private void mnuDelete_Click(object sender, EventArgs e)
 		{
 			if(lstLabels.SelectedIndices.Count > 0) {
-				int topIndex = lstLabels.TopItem.Index;
 				int lastSelectedIndex = lstLabels.SelectedIndices[lstLabels.SelectedIndices.Count - 1];
 				List<int> selectedIndexes = new List<int>(lstLabels.SelectedIndices.Cast<int>().ToList());
 				for(int i = selectedIndexes.Count - 1; i >= 0; i--) {
@@ -230,10 +229,7 @@ namespace Mesen.GUI.Debugger.Controls
 					LabelManager.DeleteLabel(label, i == 0);
 				}
 				
-				//Reposition scroll bar and selected/focused item
-				if(lstLabels.Items.Count > topIndex) {
-					lstLabels.TopItem = lstLabels.Items[topIndex];
-				}
+				//Reposition selected/focused item
 				if(lastSelectedIndex < lstLabels.Items.Count) {
 					lstLabels.Items[lastSelectedIndex].Selected = true;
 				} else if(lstLabels.Items.Count > 0) {

--- a/UI/Forms/Tools/ctrlCheatFinder.Designer.cs
+++ b/UI/Forms/Tools/ctrlCheatFinder.Designer.cs
@@ -222,6 +222,7 @@ namespace Mesen.GUI.Forms
 			this.nudCurrentFilterValue.Name = "nudCurrentFilterValue";
 			this.nudCurrentFilterValue.Size = new System.Drawing.Size(61, 21);
 			this.nudCurrentFilterValue.TabIndex = 2;
+			this.nudCurrentFilterValue.Hexadecimal = true;
 			this.nudCurrentFilterValue.Value = new decimal(new int[] {
             0,
             0,

--- a/UI/Forms/Tools/ctrlCheatFinder.Designer.cs
+++ b/UI/Forms/Tools/ctrlCheatFinder.Designer.cs
@@ -1,0 +1,460 @@
+namespace Mesen.GUI.Forms
+{
+	partial class ctrlCheatFinder
+	{
+		/// <summary> 
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary> 
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing && (components != null)) {
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Component Designer generated code
+
+		/// <summary> 
+		/// Required method for Designer support - do not modify 
+		/// the contents of this method with the code editor.
+		///
+		/// Despite warnings, this method was changed manually :),
+		/// get rekt Designer.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			this.tmrRefresh = new System.Windows.Forms.Timer(this.components);
+			this.grpFilters = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+			this.lblPreviousValue = new System.Windows.Forms.Label();
+			this.cboPrevFilterType = new System.Windows.Forms.ComboBox();
+			this.btnAddPrevFilter = new System.Windows.Forms.Button();
+			this.flowLayoutPanel4 = new System.Windows.Forms.FlowLayoutPanel();
+			this.lblCurrentValue = new System.Windows.Forms.Label();
+			this.cboCurrentFilterType = new System.Windows.Forms.ComboBox();
+			this.chkHex = new System.Windows.Forms.CheckBox();
+			this.nudCurrentFilterValue = new System.Windows.Forms.NumericUpDown();
+			this.btnAddCurrentFilter = new System.Windows.Forms.Button();
+			this.btnReset = new System.Windows.Forms.Button();
+			this.btnUndo = new System.Windows.Forms.Button();
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.lstAddresses = new Mesen.GUI.Debugger.Controls.ctrlAddressList();
+			this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.mnuCreateCheat = new System.Windows.Forms.ToolStripMenuItem();
+			this.mnuAddWatch = new System.Windows.Forms.ToolStripMenuItem();
+			this.btnCreateCheat = new System.Windows.Forms.Button();
+			this.btnAddWatch = new System.Windows.Forms.Button();
+			this.lblAtAddress = new System.Windows.Forms.Label();
+			this.lblAddress = new System.Windows.Forms.Label();
+			this.chkPauseGameWhileWindowActive = new System.Windows.Forms.CheckBox();
+			this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+			this.btn8Bit = new System.Windows.Forms.RadioButton();
+			this.btn16Bit = new System.Windows.Forms.RadioButton();
+			this.grpFilters.SuspendLayout();
+			this.tableLayoutPanel2.SuspendLayout();
+			this.flowLayoutPanel1.SuspendLayout();
+			this.flowLayoutPanel4.SuspendLayout();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.contextMenuStrip.SuspendLayout();
+			this.tableLayoutPanel3.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// tmrRefresh
+			// 
+			this.tmrRefresh.Tick += new System.EventHandler(this.tmrRefresh_Tick);
+			// 
+			// grpFilters
+			// 
+			this.grpFilters.Controls.Add(this.tableLayoutPanel2);
+			this.grpFilters.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.grpFilters.Location = new System.Drawing.Point(3, 3);
+			this.grpFilters.Name = "grpFilters";
+			this.grpFilters.Size = new System.Drawing.Size(399, 162);
+			this.grpFilters.TabIndex = 4;
+			this.grpFilters.TabStop = false;
+			this.grpFilters.Text = "Filters";
+			// 
+			// tableLayoutPanel2
+			// 
+			this.tableLayoutPanel2.ColumnCount = 2;
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 0, 2);
+			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel4, 0, 1);
+			this.tableLayoutPanel2.Controls.Add(this.btnReset, 0, 0);
+			this.tableLayoutPanel2.Controls.Add(this.btnUndo, 1, 0);
+			this.tableLayoutPanel2.Controls.Add(this.btn8Bit, 0, 4);
+			this.tableLayoutPanel2.Controls.Add(this.btn16Bit, 1, 4);
+			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
+			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+			this.tableLayoutPanel2.RowCount = 5;
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel2.Size = new System.Drawing.Size(393, 143);
+			this.tableLayoutPanel2.TabIndex = 13;
+			// 
+			// flowLayoutPanel1
+			// 
+			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel1, 2);
+			this.flowLayoutPanel1.Controls.Add(this.lblPreviousValue);
+			this.flowLayoutPanel1.Controls.Add(this.cboPrevFilterType);
+			this.flowLayoutPanel1.Controls.Add(this.btnAddPrevFilter);
+			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 59);
+			this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
+			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+			this.flowLayoutPanel1.Size = new System.Drawing.Size(393, 31);
+			this.flowLayoutPanel1.TabIndex = 1;
+			// 
+			// lblPreviousValue
+			// 
+			this.lblPreviousValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.lblPreviousValue.AutoSize = true;
+			this.lblPreviousValue.Location = new System.Drawing.Point(3, 8);
+			this.lblPreviousValue.Name = "lblPreviousValue";
+			this.lblPreviousValue.Size = new System.Drawing.Size(99, 13);
+			this.lblPreviousValue.TabIndex = 3;
+			this.lblPreviousValue.Text = "Previous value was";
+			// 
+			// cboPrevFilterType
+			// 
+			this.cboPrevFilterType.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.cboPrevFilterType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboPrevFilterType.FormattingEnabled = true;
+			this.cboPrevFilterType.Location = new System.Drawing.Point(108, 4);
+			this.cboPrevFilterType.Name = "cboPrevFilterType";
+			this.cboPrevFilterType.Size = new System.Drawing.Size(110, 21);
+			this.cboPrevFilterType.TabIndex = 0;
+			// 
+			// btnAddPrevFilter
+			// 
+			this.btnAddPrevFilter.AutoSize = true;
+			this.btnAddPrevFilter.Location = new System.Drawing.Point(224, 3);
+			this.btnAddPrevFilter.Name = "btnAddPrevFilter";
+			this.btnAddPrevFilter.Size = new System.Drawing.Size(75, 23);
+			this.btnAddPrevFilter.TabIndex = 2;
+			this.btnAddPrevFilter.Text = "Add Filter";
+			this.btnAddPrevFilter.UseVisualStyleBackColor = true;
+			this.btnAddPrevFilter.Click += new System.EventHandler(this.btnAddPrevFilter_Click);
+			// 
+			// flowLayoutPanel4
+			// 
+			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel4, 2);
+			this.flowLayoutPanel4.Controls.Add(this.lblCurrentValue);
+			this.flowLayoutPanel4.Controls.Add(this.cboCurrentFilterType);
+			this.flowLayoutPanel4.Controls.Add(this.nudCurrentFilterValue);
+			this.flowLayoutPanel4.Controls.Add(this.btnAddCurrentFilter);
+			this.flowLayoutPanel4.Controls.Add(this.chkHex);
+			this.flowLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.flowLayoutPanel4.Location = new System.Drawing.Point(0, 29);
+			this.flowLayoutPanel4.Margin = new System.Windows.Forms.Padding(0);
+			this.flowLayoutPanel4.Name = "flowLayoutPanel4";
+			this.flowLayoutPanel4.Size = new System.Drawing.Size(393, 30);
+			this.flowLayoutPanel4.TabIndex = 0;
+			// 
+			// lblCurrentValue
+			// 
+			this.lblCurrentValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.lblCurrentValue.AutoSize = true;
+			this.lblCurrentValue.Location = new System.Drawing.Point(3, 8);
+			this.lblCurrentValue.Name = "lblCurrentValue";
+			this.lblCurrentValue.Size = new System.Drawing.Size(80, 13);
+			this.lblCurrentValue.TabIndex = 4;
+			this.lblCurrentValue.Text = "Current value is";
+			// 
+			// cboCurrentFilterType
+			// 
+			this.cboCurrentFilterType.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.cboCurrentFilterType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboCurrentFilterType.FormattingEnabled = true;
+			this.cboCurrentFilterType.Location = new System.Drawing.Point(89, 4);
+			this.cboCurrentFilterType.Name = "cboCurrentFilterType";
+			this.cboCurrentFilterType.Size = new System.Drawing.Size(110, 21);
+			this.cboCurrentFilterType.TabIndex = 0;
+			// 
+			// chkHex
+			// 
+			this.chkHex.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.chkHex.Name = "chkHex";
+			this.chkHex.Checked = true;
+			this.chkHex.Text = "Hex";
+			this.chkHex.TabIndex = 1;
+			this.chkHex.Size = new System.Drawing.Size(40, 21);
+			this.chkHex.CheckedChanged += chkHex_CheckedChanged;
+			// 
+			// nudCurrentFilterValue
+			// 
+			this.nudCurrentFilterValue.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.nudCurrentFilterValue.DecimalPlaces = 0;
+			this.nudCurrentFilterValue.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+			this.nudCurrentFilterValue.Location = new System.Drawing.Point(202, 4);
+			this.nudCurrentFilterValue.Margin = new System.Windows.Forms.Padding(0);
+			this.nudCurrentFilterValue.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+			this.nudCurrentFilterValue.MaximumSize = new System.Drawing.Size(10000, 21);
+			this.nudCurrentFilterValue.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+			this.nudCurrentFilterValue.MinimumSize = new System.Drawing.Size(0, 21);
+			this.nudCurrentFilterValue.Name = "nudCurrentFilterValue";
+			this.nudCurrentFilterValue.Size = new System.Drawing.Size(61, 21);
+			this.nudCurrentFilterValue.TabIndex = 2;
+			this.nudCurrentFilterValue.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+			// 
+			// btnAddCurrentFilter
+			// 
+			this.btnAddCurrentFilter.AutoSize = true;
+			this.btnAddCurrentFilter.Location = new System.Drawing.Point(246, 3);
+			this.btnAddCurrentFilter.Name = "btnAddCurrentFilter";
+			this.btnAddCurrentFilter.Size = new System.Drawing.Size(75, 23);
+			this.btnAddCurrentFilter.TabIndex = 3;
+			this.btnAddCurrentFilter.Text = "Add Filter";
+			this.btnAddCurrentFilter.UseVisualStyleBackColor = true;
+			this.btnAddCurrentFilter.Click += new System.EventHandler(this.btnAddCurrentFilter_Click);
+			// 
+			// btnReset
+			// 
+			this.btnReset.Location = new System.Drawing.Point(3, 3);
+			this.btnReset.Name = "btnReset";
+			this.btnReset.Size = new System.Drawing.Size(75, 23);
+			this.btnReset.TabIndex = 5;
+			this.btnReset.Text = "Reset";
+			this.btnReset.UseVisualStyleBackColor = true;
+			this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
+			// 
+			// btnUndo
+			// 
+			this.btnUndo.Location = new System.Drawing.Point(84, 3);
+			this.btnUndo.Name = "btnUndo";
+			this.btnUndo.Size = new System.Drawing.Size(75, 23);
+			this.btnUndo.TabIndex = 11;
+			this.btnUndo.Text = "Undo";
+			this.btnUndo.UseVisualStyleBackColor = true;
+			this.btnUndo.Click += new System.EventHandler(this.btnUndo_Click);
+			// 
+			// tableLayoutPanel1
+			// 
+			this.tableLayoutPanel1.ColumnCount = 2;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel1.Controls.Add(this.grpFilters, 0, 0);
+			this.tableLayoutPanel1.Controls.Add(this.lstAddresses, 1, 0);
+			this.tableLayoutPanel1.Controls.Add(this.chkPauseGameWhileWindowActive, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 1, 1);
+			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 2;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(565, 196);
+			this.tableLayoutPanel1.TabIndex = 5;
+			// 
+			// lstAddresses
+			// 
+			this.lstAddresses.ContextMenuStrip = this.contextMenuStrip;
+			this.lstAddresses.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.lstAddresses.HideSelection = false;
+			this.lstAddresses.Location = new System.Drawing.Point(408, 3);
+			this.lstAddresses.Name = "lstAddresses";
+			this.lstAddresses.Size = new System.Drawing.Size(154, 162);
+			this.lstAddresses.TabIndex = 3;
+			// 
+			// contextMenuStrip
+			// 
+			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuCreateCheat, this.mnuAddWatch});
+			this.contextMenuStrip.Name = "contextMenuStrip";
+			this.contextMenuStrip.Size = new System.Drawing.Size(143, 26);
+			this.contextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
+			// 
+			// mnuCreateCheat
+			// 
+			this.mnuCreateCheat.Name = "mnuCreateCheat";
+			this.mnuCreateCheat.Size = new System.Drawing.Size(142, 22);
+			this.mnuCreateCheat.Text = "Create Cheat";
+			this.mnuCreateCheat.Image = global::Mesen.GUI.Properties.Resources.CheatCode;
+			this.mnuCreateCheat.Click += new System.EventHandler(this.btnCreateCheat_Click);
+			// 
+			// mnuAddWatch
+			// 
+			this.mnuAddWatch.Name = "mnuAddWatch";
+			this.mnuAddWatch.Size = new System.Drawing.Size(142, 22);
+			this.mnuAddWatch.Text = "Add to Watch";
+			this.mnuAddWatch.Image = global::Mesen.GUI.Properties.Resources.Find;
+			this.mnuAddWatch.Click += new System.EventHandler(this.btnAddWatch_Click);
+			// 
+			// btnCreateCheat
+			// 
+			this.btnCreateCheat.Location = new System.Drawing.Point(3, 3);
+			this.btnCreateCheat.Name = "btnCreateCheat";
+			this.btnCreateCheat.Size = new System.Drawing.Size(85, 22);
+			this.btnCreateCheat.TabIndex = 5;
+			this.btnCreateCheat.Text = "Create Cheat";
+			this.btnCreateCheat.UseVisualStyleBackColor = true;
+			this.btnCreateCheat.Click += new System.EventHandler(this.btnCreateCheat_Click);
+			// 
+			// btnAddWatch
+			// 
+			this.btnAddWatch.Location = new System.Drawing.Point(3, 3);
+			this.btnAddWatch.Name = "btnAddWatch";
+			this.btnAddWatch.Size = new System.Drawing.Size(85, 22);
+			this.btnAddWatch.TabIndex = 6;
+			this.btnAddWatch.Text = "Add to Watch";
+			this.btnAddWatch.UseVisualStyleBackColor = true;
+			this.btnAddWatch.Click += new System.EventHandler(this.btnAddWatch_Click);
+			// 
+			// lblAtAddress
+			// 
+			this.lblAtAddress.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.lblAtAddress.AutoSize = true;
+			this.lblAtAddress.Location = new System.Drawing.Point(94, 7);
+			this.lblAtAddress.Name = "lblAtAddress";
+			this.lblAtAddress.Size = new System.Drawing.Size(16, 13);
+			this.lblAtAddress.TabIndex = 7;
+			this.lblAtAddress.Text = "at";
+			// 
+			// lblAddress
+			// 
+			this.lblAddress.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.lblAddress.AutoSize = true;
+			this.lblAddress.Location = new System.Drawing.Point(116, 7);
+			this.lblAddress.Name = "lblAddress";
+			this.lblAddress.Size = new System.Drawing.Size(37, 13);
+			this.lblAddress.TabIndex = 8;
+			this.lblAddress.Text = "$00000";
+			// 
+			// chkPauseGameWhileWindowActive
+			// 
+			this.chkPauseGameWhileWindowActive.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.chkPauseGameWhileWindowActive.AutoSize = true;
+			this.chkPauseGameWhileWindowActive.Location = new System.Drawing.Point(3, 173);
+			this.chkPauseGameWhileWindowActive.Name = "chkPauseGameWhileWindowActive";
+			this.chkPauseGameWhileWindowActive.Size = new System.Drawing.Size(278, 17);
+			this.chkPauseGameWhileWindowActive.TabIndex = 6;
+			this.chkPauseGameWhileWindowActive.Text = "Automatically pause game when this window is active";
+			this.chkPauseGameWhileWindowActive.UseVisualStyleBackColor = true;
+			this.chkPauseGameWhileWindowActive.CheckedChanged += new System.EventHandler(this.chkPauseGameWhileWindowActive_CheckedChanged);
+			// 
+			// btn8Bit
+			// 
+			this.btn8Bit.Name = "btn8Bit";
+			this.btn8Bit.TabIndex = 14;
+			this.btn8Bit.Text = "8-bit";
+			this.btn8Bit.UseVisualStyleBackColor = true;
+			this.btn8Bit.Click += new System.EventHandler(this.btn8Bit_Click);
+			this.btn8Bit.Checked = true;
+			this.selectedBitButton = this.btn8Bit;
+			// 
+			// btn16Bit
+			// 
+			this.btn16Bit.Name = "btn16Bit";
+			this.btn16Bit.TabIndex = 15;
+			this.btn16Bit.Text = "16-bit";
+			this.btn16Bit.UseVisualStyleBackColor = true;
+			this.btn16Bit.Click += new System.EventHandler(this.btn16Bit_Click);
+			this.btn16Bit.Checked = false;
+			// 
+			// tableLayoutPanel3
+			// 
+			this.tableLayoutPanel3.ColumnCount = 4;
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel3.Controls.Add(this.lblAddress, 2, 0);
+			this.tableLayoutPanel3.Controls.Add(this.btnCreateCheat, 0, 0);
+			this.tableLayoutPanel3.Controls.Add(this.lblAtAddress, 1, 0);
+			this.tableLayoutPanel3.Controls.Add(this.btnAddWatch, 0, 1);
+			this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel3.Location = new System.Drawing.Point(405, 168);
+			this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+			this.tableLayoutPanel3.RowCount = 2;
+			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel3.Size = new System.Drawing.Size(160, 60);
+			this.tableLayoutPanel3.TabIndex = 7;
+			// 
+			// ctrlCheatFinder
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.tableLayoutPanel1);
+			this.Name = "ctrlCheatFinder";
+			this.Size = new System.Drawing.Size(565, 196);
+			this.grpFilters.ResumeLayout(false);
+			this.tableLayoutPanel2.ResumeLayout(false);
+			this.flowLayoutPanel1.ResumeLayout(false);
+			this.flowLayoutPanel1.PerformLayout();
+			this.flowLayoutPanel4.ResumeLayout(false);
+			this.flowLayoutPanel4.PerformLayout();
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			this.contextMenuStrip.ResumeLayout(false);
+			this.tableLayoutPanel3.ResumeLayout(false);
+			this.tableLayoutPanel3.PerformLayout();
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.Timer tmrRefresh;
+		private Debugger.Controls.ctrlAddressList lstAddresses;
+		private System.Windows.Forms.GroupBox grpFilters;
+		private System.Windows.Forms.Button btnReset;
+		private System.Windows.Forms.Button btnUndo;
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+		private System.Windows.Forms.ComboBox cboPrevFilterType;
+		private System.Windows.Forms.Button btnAddPrevFilter;
+		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel4;
+		private System.Windows.Forms.ComboBox cboCurrentFilterType;
+		private System.Windows.Forms.CheckBox chkHex;
+		private System.Windows.Forms.NumericUpDown nudCurrentFilterValue;
+		private System.Windows.Forms.Button btnAddCurrentFilter;
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+		private System.Windows.Forms.Button btnCreateCheat;
+		private System.Windows.Forms.Button btnAddWatch;
+		private System.Windows.Forms.Label lblPreviousValue;
+		private System.Windows.Forms.Label lblCurrentValue;
+		private System.Windows.Forms.Label lblAtAddress;
+		private System.Windows.Forms.Label lblAddress;
+		private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
+		private System.Windows.Forms.ToolStripMenuItem mnuCreateCheat;
+		private System.Windows.Forms.ToolStripMenuItem mnuAddWatch;
+		private System.Windows.Forms.CheckBox chkPauseGameWhileWindowActive;
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+		private System.Windows.Forms.RadioButton btn8Bit;
+		private System.Windows.Forms.RadioButton btn16Bit;
+		private System.Windows.Forms.RadioButton selectedBitButton;
+	}
+}

--- a/UI/Forms/Tools/ctrlCheatFinder.cs
+++ b/UI/Forms/Tools/ctrlCheatFinder.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Linq;
+using System.Windows.Forms;
+using Mesen.GUI.Config;
+using Mesen.GUI.Controls;
+using Mesen.GUI.Debugger;
+
+namespace Mesen.GUI.Forms
+{
+	public partial class ctrlCheatFinder : BaseControl
+	{
+		public event EventHandler OnAddCheat;
+		public bool TabIsFocused
+		{
+			set
+			{
+				_tabIsFocused = value;
+				if(chkPauseGameWhileWindowActive.Checked) {
+					if(_tabIsFocused) {
+						EmuApi.Pause();
+					} else {
+						EmuApi.Resume();
+					}
+				}
+			}
+		}
+
+		private enum BitMode
+	  	{
+			Bit8,
+			Bit16
+		}
+		private BitMode _bitMode = BitMode.Bit8;
+
+		private List<int[]> _memorySnapshots;
+		private List<FilterInfo> _filters;
+		private bool _tabIsFocused = false;
+		
+		private enum CheatPrevFilterType
+		{
+			Smaller,
+			Equal,
+			NotEqual,
+			Greater
+		}
+
+		private enum CheatCurrentFilterType
+		{
+			Smaller,
+			Equal,
+			NotEqual,
+			Greater
+		}
+
+		private class FilterInfo
+		{
+			public CheatCurrentFilterType? CurrentType;
+			public CheatPrevFilterType? PrevType;
+			public int Operand;
+		}
+
+		public ctrlCheatFinder()
+		{
+			InitializeComponent();
+
+			BaseConfigForm.InitializeComboBox(cboPrevFilterType, typeof(CheatPrevFilterType));
+			BaseConfigForm.InitializeComboBox(cboCurrentFilterType, typeof(CheatCurrentFilterType));
+			cboPrevFilterType.SelectedIndex = 0;
+			cboCurrentFilterType.SelectedIndex = 0;
+
+			btnUndo.Enabled = false;
+			
+			lstAddresses.SelectedLineChanged += lstAddresses_SelectedLineChanged;
+			lstAddresses.AddressSize = 5;
+			lstAddresses.MarginWidth = 6;
+
+			if(LicenseManager.UsageMode != LicenseUsageMode.Designtime) {
+				Reset();
+				tmrRefresh.Start();
+			}
+		}
+				
+		private void Reset()
+		{
+			_filters = new List<FilterInfo>();
+			_memorySnapshots = new List<int[]>();
+			TakeSnapshot();
+		}
+
+		private void TakeSnapshot()
+		{
+			if(!EmuApi.IsRunning()) {
+				return;
+			}
+
+			byte[] memory = GetSnapshot();
+			if(_bitMode == BitMode.Bit8) {
+				_memorySnapshots.Add(memory.Select((b) => (int)b).ToArray());
+			} else {
+				// Note the endianness
+				List<int> pairs = new List<int>(memory.Length - 1);
+				for(int i = 0; i < memory.Length - 1; ++i)
+					pairs.Add((int)memory[i + 1] * 256 + (int)memory[i]);
+				_memorySnapshots.Add(pairs.ToArray());
+			}
+			RefreshAddressList();
+
+			UpdateUI();
+		}
+
+		private byte[] GetSnapshot()
+		{
+			return DebugApi.GetMemoryState(SnesMemoryType.WorkRam);
+		}
+
+		private void tmrRefresh_Tick(object sender, EventArgs e)
+		{
+			if(_tabIsFocused) {
+				RefreshAddressList();
+			}
+		}
+
+		private void lstAddresses_SelectedLineChanged(object sender, EventArgs e)
+		{
+			UpdateUI();
+		}
+
+		private void chkHex_CheckedChanged(object sender, EventArgs e)
+		{
+			nudCurrentFilterValue.Hexadecimal = chkHex.Checked;
+			RefreshAddressList();
+		}
+
+		private void RefreshAddressList()
+		{
+			UpdateUI();
+			if(!EmuApi.IsRunning()) {
+				return;
+			}
+
+			int[] memory = _memorySnapshots[_memorySnapshots.Count - 1];
+			HashSet<int> matchingAddresses = new HashSet<int>();
+			for(int i = 0; i < memory.Length; i++) {
+				matchingAddresses.Add(i);
+			}
+
+			if(_memorySnapshots.Count > 1) {
+				for(int i = 0; i < _memorySnapshots.Count - 1; i++) {
+					matchingAddresses = new HashSet<int>(matchingAddresses.Where(addr => {
+						if(_filters[i].PrevType.HasValue) {
+							switch(_filters[i].PrevType) {
+								case CheatPrevFilterType.Smaller: return _memorySnapshots[i+1][addr] > _memorySnapshots[i][addr];
+								case CheatPrevFilterType.Equal: return _memorySnapshots[i+1][addr] == _memorySnapshots[i][addr];
+								case CheatPrevFilterType.NotEqual: return _memorySnapshots[i+1][addr] != _memorySnapshots[i][addr];
+								case CheatPrevFilterType.Greater: return _memorySnapshots[i+1][addr] < _memorySnapshots[i][addr];
+							}
+						} else {
+							switch(_filters[i].CurrentType) {
+								case CheatCurrentFilterType.Smaller: return _memorySnapshots[i+1][addr] < _filters[i].Operand;
+								case CheatCurrentFilterType.Equal: return _memorySnapshots[i+1][addr] == _filters[i].Operand;
+								case CheatCurrentFilterType.NotEqual: return _memorySnapshots[i+1][addr] != _filters[i].Operand;
+								case CheatCurrentFilterType.Greater: return _memorySnapshots[i+1][addr] > _filters[i].Operand;
+							}
+						}
+						return false;
+					}));
+				}
+			}
+
+			List<int> values = new List<int>(memory.Length);
+			List<int> addresses = new List<int>(memory.Length);
+			for(int i = 0; i < memory.Length; i++) {
+				if(matchingAddresses.Contains(i)) {
+					addresses.Add(i);
+					values.Add(memory[i]);
+				}
+			}
+			lstAddresses.SetData(values.ToArray(), addresses.ToArray(), chkHex.Checked, _bitMode == BitMode.Bit8 ? 2 : 4);
+		}
+
+		private void btnReset_Click(object sender, EventArgs e)
+		{
+			Reset();
+		}
+
+		private void btnUndo_Click(object sender, EventArgs e)
+		{
+			if(_filters.Count > 0) {
+				_filters.RemoveAt(_filters.Count-1);
+				_memorySnapshots.RemoveAt(_memorySnapshots.Count-1);
+				RefreshAddressList();
+			}
+		}
+
+		private void btn8Bit_Click(object sender, EventArgs e)
+		{
+			_bitMode = BitMode.Bit8;
+			selectedBitButton.Checked = false;
+			selectedBitButton = (System.Windows.Forms.RadioButton)sender;
+			selectedBitButton.Checked = true;
+			Reset();
+		}
+
+		private void btn16Bit_Click(object sender, EventArgs e)
+		{
+			_bitMode = BitMode.Bit16;
+			selectedBitButton.Checked = false;
+			selectedBitButton = (System.Windows.Forms.RadioButton)sender;
+			selectedBitButton.Checked = true;
+			Reset();
+		}
+
+		private void UpdateUI()
+		{
+			btnUndo.Enabled = _filters.Count > 0;
+			chkPauseGameWhileWindowActive.Enabled = btnAddCurrentFilter.Enabled = btnAddPrevFilter.Enabled = btnReset.Enabled = cboCurrentFilterType.Enabled = cboPrevFilterType.Enabled = nudCurrentFilterValue.Enabled = chkHex.Enabled = btn8Bit.Enabled = btn16Bit.Enabled = EmuApi.IsRunning();
+			mnuCreateCheat.Enabled = btnCreateCheat.Enabled = mnuAddWatch.Enabled = btnAddWatch.Enabled = lstAddresses.CurrentAddress.HasValue;
+
+			if(lstAddresses.CurrentAddress.HasValue) {
+				lblAddress.Visible = true;
+				lblAtAddress.Visible = true;
+				lblAddress.Text = "$" + lstAddresses.CurrentAddress?.ToString("X5");
+			} else {
+				lblAddress.Visible = false;
+				lblAtAddress.Visible = false;
+			}
+		}
+
+		private void btnAddPrevFilter_Click(object sender, EventArgs e)
+		{
+			_filters.Add(new FilterInfo { PrevType = (CheatPrevFilterType)cboPrevFilterType.SelectedIndex });
+			TakeSnapshot();
+		}
+
+		private void btnAddCurrentFilter_Click(object sender, EventArgs e)
+		{
+			_filters.Add(new FilterInfo { CurrentType = (CheatCurrentFilterType)cboCurrentFilterType.SelectedIndex, Operand = (int)nudCurrentFilterValue.Value });
+			TakeSnapshot();
+		}
+
+		private void contextMenuStrip_Opening(object sender, CancelEventArgs e)
+		{
+			UpdateUI();
+		}
+
+		private void btnCreateCheat_Click(object sender, EventArgs e)
+		{
+			RomInfo romInfo = EmuApi.GetRomInfo();
+			int addr = lstAddresses.CurrentAddress.Value;
+			int val = lstAddresses.CurrentValue.Value;
+
+			string codes;
+			if(_bitMode == BitMode.Bit8) {
+				codes = ((0x7E0000 + addr) * 256 + val).ToString("X8");
+			} else {
+				// Note the endianness
+				codes = ((0x7E0000 + addr) * 256 + val % 256).ToString("X8");
+				codes += "\n";
+				codes += ((0x7E0000 + addr + 1) * 256 + val / 256).ToString("X8");
+			}
+
+			CheatCode newCheat = new CheatCode {
+				Description = romInfo.GetRomName(),
+				Format = CheatFormat.ProActionReplay,
+				Enabled = true,
+				Codes = codes
+			};
+			using(frmCheat frm = new frmCheat(newCheat)) {
+				if(frm.ShowDialog() == DialogResult.OK) {
+					OnAddCheat?.Invoke(newCheat, new EventArgs());
+				}
+			}
+		}
+
+		private void btnAddWatch_Click(object sender, EventArgs e)
+		{
+			int addr = lstAddresses.CurrentAddress.Value;
+
+			// We're letting the adding with 0x7E0000 happen in the watch window,
+			// so that it's easier to see which WRAM value we're dealing with
+			string watch;
+			if(_bitMode == BitMode.Bit8) {
+				watch = "[$7E0000 + $" + addr.ToString("X5") + "]";
+			} else {
+				watch = "{$7E0000 + $" + addr.ToString("X5") + "}";
+			}
+			if(!chkHex.Checked)
+				watch += ",U";
+
+			WatchManager.GetWatchManager(CpuType.Cpu).AddWatch(watch);
+		}
+
+		private void chkPauseGameWhileWindowActive_CheckedChanged(object sender, EventArgs e)
+		{
+			if(chkPauseGameWhileWindowActive.Checked) {
+				EmuApi.Pause();
+			} else {
+				EmuApi.Resume();
+			}
+		}
+	}
+}

--- a/UI/Forms/Tools/frmCheatList.Designer.cs
+++ b/UI/Forms/Tools/frmCheatList.Designer.cs
@@ -81,6 +81,7 @@ namespace Mesen.GUI.Forms
 			this.tabMain.Name = "tabMain";
 			this.tabMain.SelectedIndex = 0;
 			this.tabMain.Size = new System.Drawing.Size(446, 324);
+			this.tabMain.SelectedIndexChanged += tabMain_SelectedIndexChanged;
 			this.tabMain.TabIndex = 0;
 			// 
 			// tabCheats

--- a/UI/Forms/Tools/frmCheatList.Designer.cs
+++ b/UI/Forms/Tools/frmCheatList.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using Mesen.GUI.Controls;
+
 namespace Mesen.GUI.Forms
 {
 	partial class frmCheatList
@@ -25,6 +26,9 @@ namespace Mesen.GUI.Forms
 		/// <summary>
 		/// Required method for Designer support - do not modify
 		/// the contents of this method with the code editor.
+		///
+		/// Despite warnings, this method was changed manually :),
+		/// get rekt Designer.
 		/// </summary>
 		private void InitializeComponent()
 		{
@@ -44,6 +48,8 @@ namespace Mesen.GUI.Forms
 			this.btnAddCheat = new System.Windows.Forms.ToolStripButton();
 			this.btnEditCheat = new System.Windows.Forms.ToolStripButton();
 			this.btnDeleteCheat = new System.Windows.Forms.ToolStripButton();
+			this.tpgCheatFinder = new System.Windows.Forms.TabPage();
+			this.ctrlCheatFinder = new ctrlCheatFinder();
 			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
 			this.chkDisableCheats = new System.Windows.Forms.CheckBox();
 			this.btnImportFromDb = new System.Windows.Forms.ToolStripButton();
@@ -53,6 +59,7 @@ namespace Mesen.GUI.Forms
 			this.tableLayoutPanel1.SuspendLayout();
 			this.contextMenuCheats.SuspendLayout();
 			this.tsCheatActions.SuspendLayout();
+			this.tpgCheatFinder.SuspendLayout();
 			this.tableLayoutPanel2.SuspendLayout();
 			this.SuspendLayout();
 			// 
@@ -67,6 +74,7 @@ namespace Mesen.GUI.Forms
 			// tabMain
 			// 
 			this.tabMain.Controls.Add(this.tabCheats);
+			this.tabMain.Controls.Add(this.tpgCheatFinder);
 			this.tabMain.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tabMain.Location = new System.Drawing.Point(0, 0);
 			this.tabMain.Margin = new System.Windows.Forms.Padding(0);
@@ -218,6 +226,25 @@ namespace Mesen.GUI.Forms
 			this.btnDeleteCheat.Size = new System.Drawing.Size(60, 20);
 			this.btnDeleteCheat.Text = "Delete";
 			this.btnDeleteCheat.Click += new System.EventHandler(this.btnDeleteCheat_Click);
+			//
+			// tpgCheatFinder
+			//
+			this.tpgCheatFinder.Controls.Add(this.ctrlCheatFinder);
+			this.tpgCheatFinder.Location = new System.Drawing.Point(4, 22);
+			this.tpgCheatFinder.Name = "tpgCheatFinder";
+			this.tpgCheatFinder.Padding = new System.Windows.Forms.Padding(3);
+			this.tpgCheatFinder.Size = new System.Drawing.Size(608, 230);
+			this.tpgCheatFinder.TabIndex = 1;
+			this.tpgCheatFinder.Text = "Cheat Finder";
+			this.tpgCheatFinder.UseVisualStyleBackColor = true;
+			//
+			// ctrlCheatFinder
+			//
+			this.ctrlCheatFinder.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.ctrlCheatFinder.Location = new System.Drawing.Point(3, 3);
+			this.ctrlCheatFinder.Name = "ctrlCheatFinder";
+			this.ctrlCheatFinder.Size = new System.Drawing.Size(602, 224);
+			this.ctrlCheatFinder.TabIndex = 0;
 			// 
 			// tableLayoutPanel2
 			// 
@@ -275,6 +302,7 @@ namespace Mesen.GUI.Forms
 			this.contextMenuCheats.ResumeLayout(false);
 			this.tsCheatActions.ResumeLayout(false);
 			this.tsCheatActions.PerformLayout();
+			this.tpgCheatFinder.ResumeLayout(false);
 			this.tableLayoutPanel2.ResumeLayout(false);
 			this.ResumeLayout(false);
 			this.PerformLayout();
@@ -301,5 +329,7 @@ namespace Mesen.GUI.Forms
 		private System.Windows.Forms.ToolStripButton btnDeleteCheat;
 		private System.Windows.Forms.ColumnHeader colEnabled;
 		private System.Windows.Forms.ToolStripButton btnImportFromDb;
+		private System.Windows.Forms.TabPage tpgCheatFinder;
+		private ctrlCheatFinder ctrlCheatFinder;
 	}
 }

--- a/UI/Forms/Tools/frmCheatList.cs
+++ b/UI/Forms/Tools/frmCheatList.cs
@@ -49,8 +49,35 @@ namespace Mesen.GUI.Forms
 				InitCheatList();
 				UpdateMenuItems();
 				chkDisableCheats.Checked = ConfigManager.Config.Cheats.DisableAllCheats;
+
+				ctrlCheatFinder.OnAddCheat += CtrlCheatFinder_OnAddCheat;
+
 				RestoreLocation(ConfigManager.Config.Cheats.WindowLocation, ConfigManager.Config.Cheats.WindowSize);
 			}
+		}
+
+		private void tabMain_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			ctrlCheatFinder.TabIsFocused = (tabMain.SelectedTab == tpgCheatFinder);
+		}
+
+		protected override void OnActivated(EventArgs e)
+		{
+			if(tabMain.SelectedTab == tpgCheatFinder) {
+				ctrlCheatFinder.TabIsFocused = true;
+			}
+			base.OnActivated(e);
+		}
+
+		protected override void OnDeactivate(EventArgs e)
+		{
+			ctrlCheatFinder.TabIsFocused = false;
+			base.OnDeactivate(e);
+		}
+
+		private void CtrlCheatFinder_OnAddCheat(object sender, EventArgs e)
+		{
+			AddCheats(new List<CheatCode>() { (CheatCode)sender });
 		}
 
 		private void InitCheatList()

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -611,6 +611,9 @@
     <Compile Include="Controls\ctrlTrackbar.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="Debugger\Controls\BaseScrollableTextboxUserControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="Controls\ctrlTrackbar.Designer.cs">
       <DependentUpon>ctrlTrackbar.cs</DependentUpon>
     </Compile>
@@ -948,6 +951,18 @@
     </Compile>
     <Compile Include="Forms\Tools\frmCheat.Designer.cs">
       <DependentUpon>frmCheat.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Forms\Tools\ctrlCheatFinder.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Forms\Tools\ctrlCheatFinder.Designer.cs">
+      <DependentUpon>ctrlCheatFinder.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Debugger\Controls\ctrlAddressList.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Debugger\Controls\ctrlAddressList.Designer.cs">
+      <DependentUpon>ctrlAddressList.cs</DependentUpon>
     </Compile>
     <Compile Include="Forms\Tools\frmCheatDbList.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Closes #11 

I have ported over the cheat finder from Mesen-X to Mesen-SX. It is mostly a faithful port, but there are some notable changes:
- Added support for finding 16 bit values
- Added toggle to switch between decimal and hex input/value displaying
- Added "add to watch" button

Some improvements that could still be made at a later point:
- Support for other memory than just WRAM (like SRAM)
- Support for 24/32 bit values
- Make "add to watch" open a watch window if none is open (either debugger or dedicated window)
- Add a window size minimum, since the cheat finder doesn't work well with small windows
- There are probably some efficiency improvements that can be made, but from my experience it's performant enough (spamming a lot of non-useful filters results in slow down, but that's to be expected)
- Gameboy support

One thing to note is that I don't have access to Visual Studio (I use Linux), so the Designer forms have been created/changed manually. Comments have been applied, noting this for the relevant files.

[Bonus bugfix] I experienced a small bug where deleting labels in the debugger resulted in an Exception when the label form was horizontally scrolled. Deleting a few lines of code in `UI/Debugger/Labels/ctrlLabelList.cs` fixed the issue for me, but since it might be a Mono issue, I recommend to test on Windows too, to see if it didn't break anything. :)