### PR TITLE
Fix deadlock when loading ROM with debugger open

### DIFF
--- a/Core/Console.cpp
+++ b/Core/Console.cpp
@@ -405,11 +405,13 @@ bool Console::LoadRom(VirtualFile romFile, VirtualFile patchFile, bool stopRom, 
 		
 		_cart = cart;
 		
-		auto lock = _debuggerLock.AcquireSafe();
-		if(_debugger) {
-			//Reset debugger if it was running before
-			_debugger->Release();
-			_debugger.reset();
+		{
+			auto lock = _debuggerLock.AcquireSafe();
+			if(_debugger) {
+				//Reset debugger if it was running before
+				_debugger->Release();
+				_debugger.reset();
+			}
 		}
 
 		_batteryManager->Initialize(FolderUtilities::GetFilename(romFile.GetFileName(), false));


### PR DESCRIPTION
Fixes #58 probably?

It fixes the bug in my testing. It should be a correct fix *if* `_debuggerLock` is only necessary to protect `_debugger` (otherwise not). I still think `SimpleLock` is incorrect under the C++ memory model, but I don't have the energy to replace it right now.

Also, you have to acquire `_debuggerLock` when *reading* as well as writing `_debugger`, or else you can read and incref the pointer while it's in the process of changing. (The current code is correct *if* when `Console::Reset()` etc. is accessing `_debugger`, there *is* no other thread capable of changing it. I don't know.)

This code is released as-is. I am not vouching that my edit is free of bugs, but I hope it's an improvement on the current state.