### PR TITLE
Fix BGE/BLT confusion

### DIFF
--- a/Core/Gsu.Instructions.cpp
+++ b/Core/Gsu.Instructions.cpp
@@ -45,12 +45,12 @@ void Gsu::BRA()
 
 void Gsu::BLT()
 {
-	Branch(_state.SFR.Sign == _state.SFR.Overflow);
+	Branch((_state.SFR.Sign ^ _state.SFR.Overflow) == 1);
 }
 
 void Gsu::BGE()
 {
-	Branch(_state.SFR.Sign != _state.SFR.Overflow);
+	Branch((_state.SFR.Sign ^ _state.SFR.Overflow) == 0);
 }
 
 void Gsu::BNE()

--- a/Core/Gsu.cpp
+++ b/Core/Gsu.cpp
@@ -106,8 +106,8 @@ void Gsu::Exec()
 		case 0x03: LSR(); break;
 		case 0x04: ROL(); break;
 		case 0x05: BRA(); break;
-		case 0x06: BLT(); break;
-		case 0x07: BGE(); break;
+		case 0x06: BGE(); break;
+		case 0x07: BLT(); break;
 		case 0x08: BNE(); break;
 		case 0x09: BEQ(); break;
 		case 0x0A: BPL(); break;

--- a/Core/GsuDisUtils.cpp
+++ b/Core/GsuDisUtils.cpp
@@ -38,8 +38,8 @@ void GsuDisUtils::GetDisassembly(DisassemblyInfo &info, string &out, uint32_t me
 		case 0x04: str.Write("ROL"); break;
 		
 		case 0x05: str.WriteAll("BRA "); getJumpTarget(); break;
-		case 0x06: str.WriteAll("BLT "); getJumpTarget(); break;
-		case 0x07: str.WriteAll("BGE "); getJumpTarget(); break;
+		case 0x06: str.WriteAll("BGE "); getJumpTarget(); break;
+		case 0x07: str.WriteAll("BLT "); getJumpTarget(); break;
 		case 0x08: str.WriteAll("BNE "); getJumpTarget(); break;
 		case 0x09: str.WriteAll("BEQ "); getJumpTarget(); break;
 		case 0x0A: str.WriteAll("BPL "); getJumpTarget(); break;


### PR DESCRIPTION
on the GSU, BGE and BLT are VERY confusing

In the official documentation, they are exchanged.

According to nocash documention, 
BGE branches if `SF ^ VF == 0` (eg: SF == VF)
BLT branches if `SF ^ VF == 1` (eg: SF != VF)

The conditions are thus inverted in Mesen-S
BUT
the opcode were inverted as well so there were no bugs. (they were also inverted in the debugger, and stepping through a program made no sense at all)

I restored the truth. According to my testing, the branches now makes perfect sense.

EG:

```asm
; R5 = $001F
; R6 = $005F
FROM R5                  
ALT3                     
CMP R6                   
BGE $02006C              
```

Doesn't take the jump as expected.

